### PR TITLE
Feature/#13 에러 핸들링 훅 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,11 @@ import SignUp from 'page/SignUp';
 
 function App() {
   return (
-
     <Routes>
       <Route path="/" element={<DefaultLayout />} />
       <Route path="/" element={<MemberInfo />} />
       <Route path="/sign-up" element={<SignUp />} />
     </Routes>
-
   );
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import SnackBar from 'page/SnackBar';
 import App from './App';
 
 const queryClient = new QueryClient();
@@ -11,5 +12,6 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <App />
     </BrowserRouter>
+    <SnackBar />
   </QueryClientProvider>,
 );

--- a/src/page/SignUp/index.tsx
+++ b/src/page/SignUp/index.tsx
@@ -2,7 +2,7 @@ import { TextField } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import {
-  useForm, Controller, UseFormGetValues, UseFormSetError,
+  useForm, Controller, UseFormGetValues,
 } from 'react-hook-form';
 import { SHA256 } from 'crypto-js';
 import { useMutation } from '@tanstack/react-query';
@@ -19,7 +19,7 @@ import Snackbar from '@mui/material/Snackbar';
 import { accessClient } from 'api/index.ts';
 import * as S from './styles.ts';
 import { useGetTracks } from 'query/tracks.ts';
-import { AxiosError } from 'axios';
+import { useSnackBar } from 'ts/useSnackBar.tsx';
 
 const status = [
   {
@@ -102,18 +102,18 @@ const phoneNumberNegExp = new RegExp(/^\d{3}-\d{3,4}-\d{4}$/);
 
 const register = (user: User) => accessClient.post('/members/register', user)
 
-interface AxiosErrorMessage {
-  message: string
-}
-
-const regist = async (user: User, getValues: UseFormGetValues<User>, joinedYear: number, joinedMonth: number, setError: UseFormSetError<User>) => {
+const regist = async (
+  user: User,
+  getValues: UseFormGetValues<User>,
+  joinedYear: number, joinedMonth:
+    number,
+  onError: (e: unknown) => void) => {
   const hash = SHA256(getValues('password')).toString();
   try {
     await register({ ...user, password: hash, joinedYear: joinedYear, joinedMonth: joinedMonth });
   }
   catch (e) {
-    const err = e as AxiosError
-    setError('root', { type: 'custom', message: (err.response?.data as AxiosErrorMessage).message })
+    onError(e)
   }
 }
 
@@ -123,20 +123,20 @@ const month = date.getMonth() + 1
 const day = date.getDate()
 
 export default function SignUp() {
-  const { control, handleSubmit, formState: { errors }, getValues, setError, clearErrors } = useForm<User>({
+  const { control, handleSubmit, formState: { errors }, getValues, clearErrors } = useForm<User>({
     mode: 'onChange',
     defaultValues: initialValue,
   });
   const { data: track } = useGetTracks();
+  const onError = useSnackBar();
 
   // Dayjs 타입을 사용하기에 부적절하다고 판단해서 새로운 state를 만듦
   const [days, setDays] = useState<Dayjs | null>(dayjs(year + '-' + month + '-' + day)); // 날짜 초기값 오늘 날짜로 임의 설정
 
   const { isPending, mutate: signUp } = useMutation({
     mutationKey: ['signup'],
-    mutationFn: ({ data, joinedYear, joinedMonth }: { data: User, joinedYear: number, joinedMonth: number }) => regist(data, getValues, joinedYear, joinedMonth, setError)
+    mutationFn: ({ data, joinedYear, joinedMonth }: { data: User, joinedYear: number, joinedMonth: number }) => regist(data, getValues, joinedYear, joinedMonth, onError)
   });
-
   return (
     <form css={S.template} onSubmit={handleSubmit((data) => {
       if (days) {
@@ -147,7 +147,8 @@ export default function SignUp() {
       }
     }
     )
-    }>
+    }
+    >
       <Snackbar
         open={!!errors.root}
         autoHideDuration={5000}

--- a/src/page/SignUp/index.tsx
+++ b/src/page/SignUp/index.tsx
@@ -123,7 +123,7 @@ const month = date.getMonth() + 1
 const day = date.getDate()
 
 export default function SignUp() {
-  const { control, handleSubmit, formState: { errors }, getValues, setError } = useForm<User>({
+  const { control, handleSubmit, formState: { errors }, getValues, setError, clearErrors } = useForm<User>({
     mode: 'onChange',
     defaultValues: initialValue,
   });
@@ -152,6 +152,7 @@ export default function SignUp() {
         open={!!errors.root}
         autoHideDuration={5000}
         message={errors.root?.message}
+        onClose={() => clearErrors('root')}
       />
       {isPending &&
         <Backdrop

--- a/src/page/SnackBar/index.tsx
+++ b/src/page/SnackBar/index.tsx
@@ -1,0 +1,19 @@
+import { useStore } from 'ts/useSnackBar';
+import Snackbar from '@mui/material/Snackbar';
+
+export default function SnackBar() {
+  const { showSnackBar, message, close } = useStore();
+
+  return (
+    <div>
+      {showSnackBar && message}
+      <Snackbar
+        open={showSnackBar}
+        autoHideDuration={3000}
+        message={message}
+        onClose={close}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      />
+    </div>
+  );
+}

--- a/src/ts/useSnackBar.tsx
+++ b/src/ts/useSnackBar.tsx
@@ -1,0 +1,34 @@
+import { AxiosError } from 'axios';
+import { create } from 'zustand';
+
+interface SnackBar {
+  showSnackBar: boolean,
+  message: string,
+  open: () => void,
+  close: () => void,
+  setMessage: (errorMessage: string) => void
+}
+
+interface AxiosErrorMessage {
+  message: string
+}
+
+export const useStore = create<SnackBar>((set) => ({
+  showSnackBar: false,
+  message: '',
+  open: () => set({ showSnackBar: true }),
+  close: () => set({ showSnackBar: false }),
+  setMessage: (message: string) => set({ message }),
+}));
+
+export const useSnackBar = () => {
+  const { open, setMessage } = useStore();
+  const onError = (e: unknown) => {
+    const err = e as AxiosError;
+    const { message } = (err.response?.data as AxiosErrorMessage);
+    setMessage(message);
+    open();
+  };
+
+  return onError;
+};


### PR DESCRIPTION
## [#13 ] request

에러 핸들링 훅을 추가 했습니다.
SnackBar 컴포넌트는 3초 후 자동으로 닫힘

사용방법
1. const onError = useSnackBar()
2. fetch 함수 내부에서 catch 부분에 onError를 에러 객체를 담아서 사용

사용해보시고 불편한 점이나 개선할만한 내용 말씀해주세요

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `develop` branch?

### Screenshot
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/101871802/5c9cddb7-164f-4230-8c39-7e42e6da4886)

### Precautions (main files for this PR ...)

Close #13 