### PR TITLE
[회원생성] 비밀번호 SHA256암호화, 버튼 충돌 수정, 생성 후 폼 초기화

### DIFF
--- a/src/component/modal/memberCreateModal/index.tsx
+++ b/src/component/modal/memberCreateModal/index.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { useCreateMember } from 'query/members';
 import { useGetTracks } from 'query/tracks';
 import { FileResponse, getPresignedUrl } from 'api/image';
+import { SHA256 } from 'crypto-js';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import axios from 'axios';
 import * as S from './style';
@@ -82,7 +83,8 @@ export default function MemberCreateModal({ open, onClose }: MemberInfoModalProp
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = event.target; setMember({ ...member, [name]: value });
+    const { name, value } = event.target;
+    setMember({ ...member, [name]: value });
   };
 
   const handleTrackChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -116,15 +118,16 @@ export default function MemberCreateModal({ open, onClose }: MemberInfoModalProp
   };
 
   const handleSave = () => {
-    if (member) {
+    if (member && member.password) {
       if (imageInfo?.presignedUrl) {
         uploadImage({ presignedUrl: imageInfo.presignedUrl, file: imageInfo.file });
-        createMember(toMemberCreate({ ...member, profileImageUrl: DEFAULT_URL + imageInfo.presignedUrl.fileName }));
+        createMember(toMemberCreate({ ...member, password: SHA256(member.password).toString(), profileImageUrl: DEFAULT_URL + imageInfo.presignedUrl.fileName }));
       } else {
-        createMember(toMemberCreate(member));
+        createMember(toMemberCreate({ ...member, password: SHA256(member.password).toString() }));
       }
     }
     onClose();
+    setMember(null);
   };
 
   const handleClose = () => {

--- a/src/page/MemberInfo/ListLayout/index.tsx
+++ b/src/page/MemberInfo/ListLayout/index.tsx
@@ -28,15 +28,15 @@ export default function ListLayout({ deleteMemberChecked }: ListLayoutProps) {
   };
 
   const columns: GridColDef[] = [
-    { field: 'name', headerName: '이름', width: 100 },
-    { field: 'trackName', headerName: '트랙', width: 130 },
-    { field: 'memberType', headerName: '직책', width: 130 },
+    { field: 'name', headerName: '이름', width: 95 },
+    { field: 'trackName', headerName: '트랙', width: 120 },
+    { field: 'memberType', headerName: '직책', width: 120 },
     { field: 'status', headerName: '상태', width: 100 },
-    { field: 'company', headerName: '소속', width: 160 },
-    { field: 'department', headerName: '학부', width: 130 },
+    { field: 'company', headerName: '소속', width: 170 },
+    { field: 'department', headerName: '학부', width: 140 },
     { field: 'studentNumber', headerName: '학번', width: 130 },
     { field: 'phoneNumber', headerName: '전화번호', width: 150 },
-    { field: 'email', headerName: '이메일', width: 220 },
+    { field: 'email', headerName: '이메일', width: 225 },
     {
       field: 'update',
       headerName: '정보수정',

--- a/src/page/MemberInfo/TrackFilter/index.tsx
+++ b/src/page/MemberInfo/TrackFilter/index.tsx
@@ -27,7 +27,7 @@ export default function TrackFilter() {
           <ToggleButton
             key={track.id}
             value={track.name}
-            sx={{ width: '100px' }}
+            sx={{ width: '90px' }}
             onClick={() => setTrack(track.id, track.name)}
           >
             {track.name}

--- a/src/page/MemberInfo/index.tsx
+++ b/src/page/MemberInfo/index.tsx
@@ -36,15 +36,7 @@ export default function MemberInfo() {
       </div>
       <div>
         <div css={S.buttonContainer}>
-          <Button
-            variant="outlined"
-            color="primary"
-            startIcon={<AddIcon />}
-            onClick={handleOpenMemberCreateModal}
-          >
-            생성
-          </Button>
-          <FormControlLabel control={<Switch checked={deleteMemberChecked} onChange={handleChangedDeleteMember} />} label="탈퇴 회원" />
+          <FormControlLabel control={<Switch checked={deleteMemberChecked} onChange={handleChangedDeleteMember} sx={{ marginLeft: 2 }} />} label="탈퇴 회원" />
           <Suspense fallback={<div />}>
             <TrackFilter />
           </Suspense>
@@ -69,6 +61,18 @@ export default function MemberInfo() {
           <Suspense fallback={<div />}>
             {layout === 'list' ? <ListLayout deleteMemberChecked={deleteMemberChecked} /> : <GridLayout />}
           </Suspense>
+          <div css={S.createButtonContainer}>
+            <div css={S.createButton}>
+              <Button
+                variant="outlined"
+                color="primary"
+                startIcon={<AddIcon />}
+                onClick={handleOpenMemberCreateModal}
+              >
+                회원 생성
+              </Button>
+            </div>
+          </div>
         </div>
         <MemberCreateModal
           open={memberCreateModalOpen}

--- a/src/page/MemberInfo/style.ts
+++ b/src/page/MemberInfo/style.ts
@@ -48,7 +48,7 @@ export const buttonContainer = css`
   justify-content: flex-end;
   align-items: flex-end;
   margin-top: 10px;
-  gap: 50px;
+  gap: 30px;
 `;
 
 export const layoutButtonContainer = css`
@@ -70,4 +70,15 @@ export const container = css`
 export const logo = css`
   width: 100%;
   margin-top: -10px;
+`;
+
+export const createButtonContainer = css`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+`;
+
+export const createButton = css`
+  width: 130px;
+  height: 65px;
 `;


### PR DESCRIPTION
## [#70 #71 #73 #74 ] request

- 비밀번호 암호화 적용 및 테스트 완료했습니다.
- 회원생성 버튼을 하단으로 이동시키고, 트랙필터 버튼의 width를 줄여 상단의 버튼 공간을 확보했습니다.
- 회원생성에 성공하면 폼을 초기화 시키도록 수정했습니다.
- 데이터 필드 width를 조절하여 메카트로닉스공학부 글자가 짤리지 않도록 수정하였습니다.

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot
<img width="1698" alt="image" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/47723a8d-dac2-4f29-90a2-d56b52c92005">


### Precautions (main files for this PR ...)

Close #70 Close #71 Close #73 Close #74
