### PR TITLE
[마이페이지] 프로필 이미지 미업로드시 기본 프로필 적용

### DIFF
--- a/src/page/MyPage/index.tsx
+++ b/src/page/MyPage/index.tsx
@@ -8,6 +8,7 @@ import { useGetMe, useUpdateMe } from 'query/members';
 import { FileResponse, getPresignedUrl } from 'api/image';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import axios from 'axios';
+import { useForm } from 'react-hook-form';
 import * as S from './style';
 
 const MEMBER_TYPE_LABEL = {
@@ -40,7 +41,8 @@ export default function MyPage() {
   const { data: getMe } = useGetMe();
   const DEFAULT_URL = 'https://image.bcsdlab.com/';
   const DEFAULT_PROFILE = 'https://image.bcsdlab.com/default-profile.png';
-  const [imageUrl, setImageUrl] = useState<string>('');
+  const { watch, setValue } = useForm();
+  const imageUrl = watch('profileImage');
 
   interface FileInfo {
     file: File;
@@ -51,9 +53,10 @@ export default function MyPage() {
     () => {
       if (getMe) {
         setMember(getMe);
+        setValue('profileImage', getMe.profileImageUrl || DEFAULT_PROFILE);
       }
     },
-    [getMe],
+    [getMe, setValue],
   );
 
   const formatPhoneNumber = (input: string) => {
@@ -93,7 +96,7 @@ export default function MyPage() {
       });
 
       setImageInfo({ file, presignedUrl: presigned });
-      setImageUrl(URL.createObjectURL(file));
+      setValue('profileImage', URL.createObjectURL(file));
     }
   };
 
@@ -283,7 +286,7 @@ export default function MyPage() {
               <div css={S.imageContainer}>
                 <img
                   css={S.profileImage}
-                  src={imageUrl || member?.profileImageUrl || DEFAULT_PROFILE}
+                  src={imageUrl}
                   alt="profileImage"
                 />
                 <div css={S.buttonWrapper}>
@@ -311,7 +314,6 @@ export default function MyPage() {
                 </div>
               </div>
             </div>
-
           </Box>
         </Box>
       </div>

--- a/src/page/MyPage/index.tsx
+++ b/src/page/MyPage/index.tsx
@@ -38,7 +38,7 @@ export default function MyPage() {
   const { data: tracks } = useGetTracks();
   const { mutate: updateMe } = useUpdateMe();
   const { data: getMe } = useGetMe();
-  const DEFAULT_URL = 'https://image.bcsdlab.com/';
+  const DEFAULT_PROFILE = 'https://image.bcsdlab.com/default-profile.png';
   const [imageUrl, setImageUrl] = useState<string>('');
 
   interface FileInfo {
@@ -111,7 +111,7 @@ export default function MyPage() {
         updateMe({
           ...member,
           trackId: member.track?.id,
-          profileImageUrl: DEFAULT_URL + imageInfo.presignedUrl.fileName,
+          profileImageUrl: DEFAULT_PROFILE + imageInfo.presignedUrl.fileName,
         });
       } else {
         updateMe({
@@ -281,8 +281,8 @@ export default function MyPage() {
               />
               <div css={S.imageContainer}>
                 <img
-                  css={S.image}
-                  src={imageUrl || member?.profileImageUrl}
+                  css={S.profileImage}
+                  src={imageUrl || member?.profileImageUrl || DEFAULT_PROFILE}
                   alt="profileImage"
                 />
                 <div css={S.buttonWrapper}>

--- a/src/page/MyPage/index.tsx
+++ b/src/page/MyPage/index.tsx
@@ -38,6 +38,7 @@ export default function MyPage() {
   const { data: tracks } = useGetTracks();
   const { mutate: updateMe } = useUpdateMe();
   const { data: getMe } = useGetMe();
+  const DEFAULT_URL = 'https://image.bcsdlab.com/';
   const DEFAULT_PROFILE = 'https://image.bcsdlab.com/default-profile.png';
   const [imageUrl, setImageUrl] = useState<string>('');
 
@@ -111,7 +112,7 @@ export default function MyPage() {
         updateMe({
           ...member,
           trackId: member.track?.id,
-          profileImageUrl: DEFAULT_PROFILE + imageInfo.presignedUrl.fileName,
+          profileImageUrl: DEFAULT_URL + imageInfo.presignedUrl.fileName,
         });
       } else {
         updateMe({

--- a/src/page/MyPage/style.ts
+++ b/src/page/MyPage/style.ts
@@ -66,8 +66,9 @@ export const imageContainer = css`
   justify-content: space-between;
 `;
 
-export const image = css`
+export const profileImage = css`
   width: 150px;
   height: 150px;
   border: 1px solid ${colors.borderGray};
+  padding: 10px;
 `;


### PR DESCRIPTION
## [#52 ] request

- 프로필 이미지가 null인 경우 기본 프로필 사진을 보여줍니다.

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot
<img width="1703" alt="image" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/0fad98e2-5446-470f-bb94-8f8d88b126f6">


### Precautions (main files for this PR ...)

Close #52 
