### PR TITLE
회비 납부 페이지, 회비 수정 페이지 이슈 해결

### DIFF
--- a/src/page/DuesManagement/index.tsx
+++ b/src/page/DuesManagement/index.tsx
@@ -99,6 +99,8 @@ function DefaultTable() {
       setMemoAnchorEl(e.currentTarget);
       if (dueDetail.memo) {
         setDetail(dueDetail);
+      } else {
+        setDetail({ month: dueDetail.month, status: dueDetail.status, memo: '사유 없음' });
       }
     }
   };
@@ -250,8 +252,6 @@ function DefaultTable() {
                       onClick={(e) => handleMemoClick(e, dueDetail)}
                       key={dueDetail.month}
                     >
-                      {/* TODO: detail.status에 따른 UI */}
-                      {/* 미납 X(빨강), 면제 -(초록), 납부 O(초록), null -(default) */}
                       {dueDetail.status !== null ? STATUS_MAPPING[dueDetail.status] : '-'}
                     </TableCell>
                   ))}

--- a/src/page/DuesManagement/index.tsx
+++ b/src/page/DuesManagement/index.tsx
@@ -15,7 +15,7 @@ import {
 import { useGetAllDues } from 'query/dues';
 import useBooleanState from 'util/hooks/useBooleanState.ts';
 import { DuesDetail } from 'model/dues/allDues';
-import { STATUS, STATUS_MAPPING } from 'util/constants/status';
+import { LAST_DUES_YEAR, STATUS, STATUS_MAPPING } from 'util/constants/status';
 import { useGetTracks } from 'query/tracks';
 import LoadingSpinner from 'layout/LoadingSpinner';
 import {
@@ -29,7 +29,6 @@ function DefaultTable() {
   const navigate = useNavigate();
   const page = useQueryParam('page', 'number') as number | null;
   const currentYear = new Date().getFullYear();
-  const lastDuesYear = 2021;
   const [duesYear, setDuesYear] = useState(page ? currentYear - page + 1 : currentYear);
   const [trackFilter, setTrackFilter] = useState([true, true, true, true, true, true]);
   const [name, setName] = useState('');
@@ -128,7 +127,8 @@ function DefaultTable() {
     <>
       <div css={S.searchAndPagination}>
         <div css={S.pagination}>
-          <Button onClick={goToPrevYear} disabled={duesYear === lastDuesYear}>
+          {/* 회비 데이터의 마지막 연도는 2021년 입니다. */}
+          <Button onClick={goToPrevYear} disabled={duesYear === LAST_DUES_YEAR}>
             <ArrowBackIosNewOutlined />
           </Button>
           <span css={S.paginationTitle}>{duesYear}</span>

--- a/src/page/DuesManagement/index.tsx
+++ b/src/page/DuesManagement/index.tsx
@@ -18,7 +18,9 @@ import { DuesDetail } from 'model/dues/allDues';
 import { STATUS, STATUS_MAPPING } from 'util/constants/status';
 import { useGetTracks } from 'query/tracks';
 import LoadingSpinner from 'layout/LoadingSpinner';
-import { ArrowBackIosNewOutlined, ArrowForwardIosOutlined } from '@mui/icons-material';
+import {
+  ArrowBackIosNewOutlined, ArrowDownward, ArrowForwardIosOutlined, ArrowUpward, Sort,
+} from '@mui/icons-material';
 import useQueryParam from 'util/hooks/useQueryParam';
 import makeNumberArray from 'util/hooks/makeNumberArray';
 import * as S from './style';
@@ -31,8 +33,9 @@ function DefaultTable() {
   const [trackFilter, setTrackFilter] = useState([true, true, true, true, true, true]);
   const [name, setName] = useState('');
   const [detail, setDetail] = useState<DuesDetail>({ month: 0, status: null });
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const memoPopOverOpen = Boolean(anchorEl);
+  const [memoAnchorEl, setMemoAnchorEl] = useState<null | HTMLElement>(null);
+  const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
+  const memoPopOverOpen = Boolean(memoAnchorEl);
   const {
     value: isFilterModalOpen,
     setTrue: openFilterModal,
@@ -81,9 +84,19 @@ function DefaultTable() {
     });
   };
 
+  const sortInAscendingOrderByName = () => {
+    setFilteredValue((prevValue) => prevValue.sort((a, b) => a.name.localeCompare(b.name)));
+    setSortAnchorEl(null);
+  };
+
+  const sortInDescendingOrderByName = () => {
+    setFilteredValue((prevValue) => prevValue.sort((a, b) => b.name.localeCompare(a.name)));
+    setSortAnchorEl(null);
+  };
+
   const handleMemoClick = (e: React.MouseEvent<HTMLTableCellElement>, dueDetail: DuesDetail) => {
     if (dueDetail.status === 'NOT_PAID' || dueDetail.status === 'SKIP') {
-      setAnchorEl(e.currentTarget);
+      setMemoAnchorEl(e.currentTarget);
       if (dueDetail.memo) {
         setDetail(dueDetail);
       }
@@ -112,11 +125,11 @@ function DefaultTable() {
     <>
       <div css={S.searchAndPagination}>
         <div css={S.pagination}>
-          <Button onClick={goToPrevYear}>
+          <Button onClick={goToPrevYear} disabled={duesYear === 2021}>
             <ArrowBackIosNewOutlined />
           </Button>
           <span css={S.paginationTitle}>{duesYear}</span>
-          <Button onClick={goToNextYear}>
+          <Button onClick={goToNextYear} disabled={duesYear === currentYear}>
             <ArrowForwardIosOutlined />
           </Button>
         </div>
@@ -139,13 +152,13 @@ function DefaultTable() {
                 <TableCell css={S.tableHeader}>
                   <div css={S.trackTableCell}>
                     <span>트랙</span>
-                    <button
+                    <Button
                       type="button"
                       onClick={openFilterModal}
                       css={S.filterModalButton}
                     >
-                      필터
-                    </button>
+                      <Sort css={S.sortLogo} />
+                    </Button>
                     <Modal
                       open={isFilterModalOpen}
                       onClose={closeFilterModal}
@@ -177,7 +190,44 @@ function DefaultTable() {
                   </div>
                 </TableCell>
                 <TableCell css={S.tableHeader}>미납 횟수</TableCell>
-                <TableCell css={S.tableHeader}>이름</TableCell>
+                <TableCell css={S.tableHeader}>
+                  <div css={S.nameTableCell}>
+                    <span>이름</span>
+                    <Button
+                      type="button"
+                      onClick={(e) => setSortAnchorEl(e.currentTarget)}
+                      css={S.filterModalButton}
+                    >
+                      <Sort css={S.sortLogo} />
+                    </Button>
+                    <Popover
+                      id="simple-popover"
+                      open={Boolean(sortAnchorEl)}
+                      anchorEl={sortAnchorEl}
+                      onClose={() => setSortAnchorEl(null)}
+                      anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                      }}
+                    >
+                      <div css={S.sortPopover}>
+                        <h3>
+                          이름순 정렬
+                        </h3>
+                        <div css={S.sortPopoverButtonGroup}>
+                          <Button variant="contained" color="primary" onClick={sortInAscendingOrderByName}>
+                            <ArrowDownward />
+                            오름차순
+                          </Button>
+                          <Button variant="contained" color="primary" onClick={sortInDescendingOrderByName}>
+                            <ArrowUpward />
+                            내림차순
+                          </Button>
+                        </div>
+                      </div>
+                    </Popover>
+                  </div>
+                </TableCell>
                 {makeNumberArray(12, { start: 1 }).map((month) => (
                   <TableCell key={month} css={S.tableHeader}>
                     {month}
@@ -210,8 +260,8 @@ function DefaultTable() {
               <Popover
                 id="simple-popover"
                 open={memoPopOverOpen}
-                anchorEl={anchorEl}
-                onClose={() => setAnchorEl(null)}
+                anchorEl={memoAnchorEl}
+                onClose={() => setMemoAnchorEl(null)}
                 anchorOrigin={{
                   vertical: 'bottom',
                   horizontal: 'left',

--- a/src/page/DuesManagement/index.tsx
+++ b/src/page/DuesManagement/index.tsx
@@ -29,6 +29,7 @@ function DefaultTable() {
   const navigate = useNavigate();
   const page = useQueryParam('page', 'number') as number | null;
   const currentYear = new Date().getFullYear();
+  const lastDuesYear = 2021;
   const [duesYear, setDuesYear] = useState(page ? currentYear - page + 1 : currentYear);
   const [trackFilter, setTrackFilter] = useState([true, true, true, true, true, true]);
   const [name, setName] = useState('');
@@ -127,7 +128,7 @@ function DefaultTable() {
     <>
       <div css={S.searchAndPagination}>
         <div css={S.pagination}>
-          <Button onClick={goToPrevYear} disabled={duesYear === 2021}>
+          <Button onClick={goToPrevYear} disabled={duesYear === lastDuesYear}>
             <ArrowBackIosNewOutlined />
           </Button>
           <span css={S.paginationTitle}>{duesYear}</span>

--- a/src/page/DuesManagement/style.ts
+++ b/src/page/DuesManagement/style.ts
@@ -2,15 +2,6 @@ import { css } from '@emotion/react';
 import { colors } from 'const/colors/style';
 import { DuesDetail } from 'model/dues/allDues';
 
-export const sidebar = css`
-  display: flex;
-  flex-direction: column;
-  width: 250px;
-  min-height: calc(100vh - 10px);
-  background-color: ${colors.gray};
-  border-right: 1px solid ${colors.borderGray};
-`;
-
 export const topBar = css`
   width: 100%;
   height: 100px;
@@ -29,7 +20,6 @@ export const mainContent = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: calc(100vw - 250px);
   min-height: calc(100vh - 250px);
 `;
 
@@ -78,7 +68,11 @@ export const tableHeader = css`
 
 export const trackTableCell = css`
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+`;
+
+export const nameTableCell = css`
+  display: flex;
   align-items: center;
 `;
 
@@ -91,9 +85,26 @@ export const filterModalButton = css`
   padding: 8px 16px;
   border-radius: 8px;
   cursor: pointer;
-  border: 1px solid #eeeeee;
-  color: #212121;
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+`;
+
+export const sortLogo = css`
+  color: #ffffff;
+`;
+
+export const sortPopover = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  min-width: 150px;
+  min-height: 70px;
+`;
+
+export const sortPopoverButtonGroup = css`
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
 `;
 
 export const filterModal = css`

--- a/src/page/DuesSetup/index.tsx
+++ b/src/page/DuesSetup/index.tsx
@@ -24,6 +24,8 @@ interface DatesDuesApply {
   prevYearMonth: number[];
   currentYearMonth: number[];
 }
+
+type Column = 'date' | 'category' | 'amount' | 'balance' | 'name' | 'note' | 'month';
 // 회비 생성
 // 매월 1일에 회비 생성 (단 한번만 하는 기능임)
 
@@ -75,29 +77,30 @@ export default function DuesSetup() {
     onSuccess: () => onMutationSuccess(),
   });
 
+  const columns: Column[] = ['date', 'category', 'amount', 'balance', 'name', 'note', 'month'];
   const sortInAscendingOrderByName = () => {
-    const rowData = tableBody[4].value.map((name, index) => {
-      return {
-        name,
-        date: tableBody[0].value[index],
-        category: tableBody[1].value[index],
-        amount: tableBody[2].value[index],
-        balance: tableBody[3].value[index],
-        note: tableBody[5].value[index],
-        month: tableBody[6].value[index],
+    const rowData = tableBody[4].value.map((_, index) => {
+      const newRowData: Record<Column, string> = {
+        date: '',
+        category: '',
+        amount: '',
+        balance: '',
+        name: '',
+        note: '',
+        month: '',
       };
+      columns.forEach((col, colIndex) => {
+        newRowData[col] = tableBody[colIndex].value[index];
+      });
+      return newRowData;
     });
     rowData.sort((a, b) => a.name.localeCompare(b.name));
     rowData.forEach((value, index) => {
       setTableBody((prev) => {
         const newTableBody = [...prev];
-        newTableBody[0].value[index] = value.date;
-        newTableBody[1].value[index] = value.category;
-        newTableBody[2].value[index] = value.amount;
-        newTableBody[3].value[index] = value.balance;
-        newTableBody[4].value[index] = value.name;
-        newTableBody[5].value[index] = value.note;
-        newTableBody[6].value[index] = value.month;
+        columns.forEach((col, colIndex) => {
+          newTableBody[colIndex].value[index] = value[col];
+        });
         return newTableBody;
       });
     });
@@ -105,28 +108,28 @@ export default function DuesSetup() {
   };
 
   const sortInDescendingOrderByName = () => {
-    const rowData = tableBody[4].value.map((name, index) => {
-      return {
-        name,
-        date: tableBody[0].value[index],
-        category: tableBody[1].value[index],
-        amount: tableBody[2].value[index],
-        balance: tableBody[3].value[index],
-        note: tableBody[5].value[index],
-        month: tableBody[6].value[index],
+    const rowData = tableBody[4].value.map((_, index) => {
+      const newRowData: Record<Column, string> = {
+        date: '',
+        category: '',
+        amount: '',
+        balance: '',
+        name: '',
+        note: '',
+        month: '',
       };
+      columns.forEach((col, colIndex) => {
+        newRowData[col] = tableBody[colIndex].value[index];
+      });
+      return newRowData;
     });
     rowData.sort((a, b) => b.name.localeCompare(a.name));
     rowData.forEach((value, index) => {
       setTableBody((prev) => {
         const newTableBody = [...prev];
-        newTableBody[0].value[index] = value.date;
-        newTableBody[1].value[index] = value.category;
-        newTableBody[2].value[index] = value.amount;
-        newTableBody[3].value[index] = value.balance;
-        newTableBody[4].value[index] = value.name;
-        newTableBody[5].value[index] = value.note;
-        newTableBody[6].value[index] = value.month;
+        columns.forEach((col, colIndex) => {
+          newTableBody[colIndex].value[index] = value[col];
+        });
         return newTableBody;
       });
     });

--- a/src/page/DuesSetup/index.tsx
+++ b/src/page/DuesSetup/index.tsx
@@ -101,6 +101,7 @@ export default function DuesSetup() {
         return newTableBody;
       });
     });
+    setAnchorEl(null);
   };
 
   const sortInDescendingOrderByName = () => {
@@ -129,6 +130,7 @@ export default function DuesSetup() {
         return newTableBody;
       });
     });
+    setAnchorEl(null);
   };
 
   const findUnpaidMonth = (dues: Dues[], name: string) => {

--- a/src/page/DuesSetup/style.ts
+++ b/src/page/DuesSetup/style.ts
@@ -31,6 +31,10 @@ export const tableCell = css`
   width: 100px;
 `;
 
+export const tableNameHeader = css`
+  width: 100px;
+`;
+
 export const mainContent = css`
   position: relative;
   display: flex;
@@ -79,4 +83,20 @@ export const modalContainer = css`
 export const modalContent = css`
   display: flex;
   flex-direction: column;
+`;
+
+export const sortPopover = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  min-width: 150px;
+  min-height: 70px;
+`;
+
+export const sortPopoverButtonGroup = css`
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
 `;

--- a/src/page/EditDues/index.tsx
+++ b/src/page/EditDues/index.tsx
@@ -6,7 +6,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import {
-  Button, Checkbox, FormControl, FormControlLabel, FormGroup, FormLabel, Input, Radio, RadioGroup,
+  Button, Checkbox, FormControl, FormControlLabel, FormGroup, FormLabel, Input, Popover, Radio, RadioGroup,
 } from '@mui/material';
 import Modal from '@mui/material/Modal';
 import {
@@ -17,7 +17,9 @@ import useBooleanState from 'util/hooks/useBooleanState.ts';
 import { STATUS_MAPPING } from 'util/constants/status';
 import { useGetTracks } from 'query/tracks';
 import LoadingSpinner from 'layout/LoadingSpinner';
-import { ArrowBackIosNewOutlined, ArrowForwardIosOutlined } from '@mui/icons-material';
+import {
+  ArrowBackIosNewOutlined, ArrowDownward, ArrowForwardIosOutlined, ArrowUpward, Sort,
+} from '@mui/icons-material';
 import useQueryParam from 'util/hooks/useQueryParam';
 import { useSnackBar } from 'ts/useSnackBar';
 import makeNumberArray from 'util/hooks/makeNumberArray';
@@ -51,6 +53,7 @@ function DefaultTable() {
     memo: '',
   });
   const [status, setStatus] = useState<Status>('PAID');
+  const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
 
   const openSnackBar = useSnackBar();
 
@@ -164,15 +167,29 @@ function DefaultTable() {
       navigate(`/edit-dues?page=${page - 1}`);
     }
   };
+
+  const sortInAscendingOrderByName = () => {
+    setFilteredValue((prev) => {
+      return prev.sort((a, b) => a.name.localeCompare(b.name));
+    });
+    setSortAnchorEl(null);
+  };
+
+  const sortInDescendingOrderByName = () => {
+    setFilteredValue((prev) => {
+      return prev.sort((a, b) => b.name.localeCompare(a.name));
+    });
+    setSortAnchorEl(null);
+  };
   return (
     <>
       <div css={S.searchAndPagination}>
         <div css={S.pagination}>
-          <Button onClick={goToPrevYear}>
+          <Button onClick={goToPrevYear} disabled={duesYear === 2021}>
             <ArrowBackIosNewOutlined />
           </Button>
           <span css={S.paginationTitle}>{duesYear}</span>
-          <Button onClick={goToNextYear}>
+          <Button onClick={goToNextYear} disabled={duesYear === currentYear}>
             <ArrowForwardIosOutlined />
           </Button>
         </div>
@@ -195,13 +212,13 @@ function DefaultTable() {
                 <TableCell css={S.tableHeader}>
                   <div css={S.trackTableCell}>
                     <span>트랙</span>
-                    <button
+                    <Button
                       type="button"
                       onClick={openFilterModal}
                       css={S.filterModalButton}
                     >
-                      필터
-                    </button>
+                      <Sort css={S.sortLogo} />
+                    </Button>
                     <Modal
                       open={isFilterModalOpen}
                       onClose={closeFilterModal}
@@ -231,7 +248,44 @@ function DefaultTable() {
                   </div>
                 </TableCell>
                 <TableCell css={S.tableHeader}>미납 횟수</TableCell>
-                <TableCell css={S.tableHeader}>이름</TableCell>
+                <TableCell css={S.tableHeader}>
+                  <div css={S.nameTableCell}>
+                    <span>이름</span>
+                    <Button
+                      type="button"
+                      onClick={(e) => setSortAnchorEl(e.currentTarget)}
+                      css={S.filterModalButton}
+                    >
+                      <Sort css={S.sortLogo} />
+                    </Button>
+                    <Popover
+                      id="simple-popover"
+                      open={Boolean(sortAnchorEl)}
+                      anchorEl={sortAnchorEl}
+                      onClose={() => setSortAnchorEl(null)}
+                      anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                      }}
+                    >
+                      <div css={S.sortPopover}>
+                        <h3>
+                          이름순 정렬
+                        </h3>
+                        <div css={S.sortPopoverButtonGroup}>
+                          <Button variant="contained" color="primary" onClick={sortInAscendingOrderByName}>
+                            <ArrowDownward />
+                            오름차순
+                          </Button>
+                          <Button variant="contained" color="primary" onClick={sortInDescendingOrderByName}>
+                            <ArrowUpward />
+                            내림차순
+                          </Button>
+                        </div>
+                      </div>
+                    </Popover>
+                  </div>
+                </TableCell>
                 {makeNumberArray(12, { start: 1 }).map((month) => (
                   <TableCell key={month} css={S.tableHeader}>
                     {month}

--- a/src/page/EditDues/style.ts
+++ b/src/page/EditDues/style.ts
@@ -2,15 +2,6 @@ import { css } from '@emotion/react';
 import { colors } from 'const/colors/style';
 import { DuesDetail } from 'model/dues/allDues';
 
-export const sidebar = css`
-  display: flex;
-  flex-direction: column;
-  width: 250px;
-  min-height: calc(100vh - 10px);
-  background-color: ${colors.gray};
-  border-right: 1px solid ${colors.borderGray};
-`;
-
 export const topBar = css`
   width: 100%;
   height: 100px;
@@ -24,19 +15,11 @@ export const topBarTitle = css`
   margin-left: 16px;
 `;
 
-export const content = css`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100vw;
-`;
-
 export const mainContent = css`
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: (100vw - 250px);
   min-height: calc(100vh - 250px);
 `;
 
@@ -85,7 +68,11 @@ export const tableHeader = css`
 
 export const trackTableCell = css`
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+`;
+
+export const nameTableCell = css`
+  display: flex;
   align-items: center;
 `;
 
@@ -94,13 +81,30 @@ export const dues = css`
   height: 100%;
 `;
 
+export const sortLogo = css`
+  color: #ffffff;
+`;
+
+export const sortPopover = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  min-width: 150px;
+  min-height: 70px;
+`;
+
+export const sortPopoverButtonGroup = css`
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+`;
+
 export const filterModalButton = css`
   padding: 8px 16px;
   border-radius: 8px;
   cursor: pointer;
-  border: 1px solid #eeeeee;
-  color: #212121;
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 `;
 
 export const filterModal = css`

--- a/src/util/constants/status.ts
+++ b/src/util/constants/status.ts
@@ -9,3 +9,5 @@ export const STATUS = {
   SKIP: '면제',
   PAID: '납부',
 } as const;
+
+export const LAST_DUES_YEAR = 2021;


### PR DESCRIPTION
## [#58 #59 #64 #67 ] request
- 회비 생성, 회비 납부, 회비 수정 모든 페이지에 이름을 통한 `오름차순` `내림차순` 기능을 추가했습니다.
- `회비 납부` 페이지에서 미납 혹은 면제 사유를 볼 수 있는 팝오버 이슈를 해결하였습니다.
  - 사유가 없다면 `사유 없음` 사유 클릭 후 다른 사유를 볼 때 이전 값이 출력되는 문제를 해결하였습니다.
- 표를 넘길 때 다음 연도에 대한 값이 없는 경우 버튼을 `disabled`로 수정하였습니다.

## Please check if the PR fulfills these requirements

- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `main` branch?

### Screenshot
<img width="1710" alt="스크린샷 2024-02-29 오후 7 44 46" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/0d55a549-14d8-44ba-908d-21d50b2744d8">
<img width="1709" alt="image" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/17a1e5a3-6666-4129-8af9-c2d85a30c448">


https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/7e13251a-1779-4397-8518-6178fad9bcb4


### Precautions (main files for this PR ...)

- Close #58, #59, #64, #67
