### PR TITLE
[회원정보] 그리드 레이아웃 구현

### DIFF
--- a/src/component/modal/memberInfoModal/index.tsx
+++ b/src/component/modal/memberInfoModal/index.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 import { useUpdateMember, useDeleteMember } from 'query/members';
 import { useGetTracks } from 'query/tracks';
 import { FileResponse, getPresignedUrl } from 'api/image';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import axios from 'axios';
 import * as S from './style';
 
@@ -302,6 +303,7 @@ export default function MemberInfoModal({
               component="label"
               fullWidth
               variant="outlined"
+              startIcon={<CloudUploadIcon />}
               sx={{ height: '60px', marginTop: '15px', padding: '0px' }}
             >
               프로필 이미지

--- a/src/component/modal/memberInfoModal/index.tsx
+++ b/src/component/modal/memberInfoModal/index.tsx
@@ -15,6 +15,7 @@ interface MemberInfoModalProps {
   open: boolean;
   onClose: () => void;
   member: Member | null;
+  isList: boolean;
 }
 
 const MEMBER_TYPE_LABEL = {
@@ -59,19 +60,25 @@ interface FileInfo {
   file: File;
   presignedUrl: FileResponse;
 }
-export default function MemberInfoModal({ open, onClose, member: initialMember }: MemberInfoModalProps): React.ReactElement {
+export default function MemberInfoModal({
+  open, onClose, member: initialMember, isList,
+}: MemberInfoModalProps): React.ReactElement {
   const [member, setMember] = useState<Member | null>(initialMember);
   const { mutate: updateMember } = useUpdateMember();
   const { mutate: deleteMember } = useDeleteMember();
   const { data: tracks } = useGetTracks();
   const [imageInfo, setImageInfo] = useState<FileInfo>();
 
-  useEffect(
-    () => {
+  useEffect(() => {
+    if (isList) {
       setMember(initialMember);
-    },
-    [initialMember],
-  );
+    } else if (initialMember) {
+      setMember({
+        ...initialMember,
+        status: STATUS_LABEL[initialMember.status as keyof typeof STATUS_LABEL],
+      });
+    }
+  }, [initialMember, isList]);
 
   const formatPhoneNumber = (input: string) => {
     const numbers = input.replace(/[^\d]/g, '');

--- a/src/component/modal/memberInfoModal/index.tsx
+++ b/src/component/modal/memberInfoModal/index.tsx
@@ -72,12 +72,13 @@ export default function MemberInfoModal({
   useEffect(() => {
     if (isList) {
       setMember(initialMember);
-    } else if (initialMember) {
-      setMember({
-        ...initialMember,
-        status: STATUS_LABEL[initialMember.status as keyof typeof STATUS_LABEL],
-      });
-    }
+    } else
+      if (initialMember) {
+        setMember({
+          ...initialMember,
+          status: STATUS_LABEL[initialMember.status as keyof typeof STATUS_LABEL],
+        });
+      }
   }, [initialMember, isList]);
 
   const formatPhoneNumber = (input: string) => {

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,8 @@
 body {
   min-height: 100vh;
   min-width: 1148px;
+  background-color: #F9FAFB;
+  
 
   @include media.media-breakpoint-down(mobile) {
     min-width: 320px;

--- a/src/layout/SideBar/index.tsx
+++ b/src/layout/SideBar/index.tsx
@@ -14,11 +14,11 @@ export default function SideBar() {
       <div css={S.sideBar}>
         <img src="https://image.bcsdlab.com/banner.png" alt="logo" css={S.logo} />
         <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('member')}>회원정보</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} onClick={() => navigate('mypage')}>마이페이지</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} onClick={() => navigate('accept')}>회원승인</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} onClick={() => navigate('dues')}>회비납부</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} onClick={() => navigate('dues-setup')}>회비생성</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} onClick={() => navigate('edit-dues')}>회비수정</Button>
+        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('mypage')}>마이페이지</Button>
+        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('accept')}>회원승인</Button>
+        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues')}>회비납부</Button>
+        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues-setup')}>회비생성</Button>
+        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('edit-dues')}>회비수정</Button>
         <div css={S.logOutButton}>
           <Button variant="contained" color="secondary" sx={{ marginTop: '40vh', width: '100px' }} onClick={logOut}>로그아웃</Button>
         </div>

--- a/src/model/member.ts
+++ b/src/model/member.ts
@@ -2,7 +2,7 @@ import { Track } from './track';
 
 export type StatusType = 'ATTEND' | 'OFF' | 'IPP' | 'ARMY' | 'COMPLETION' | 'GRADUATE';
 export type StatusLabel = '재학' | '휴학' | '현장실습' | '군 휴학' | '수료' | '졸업';
-export type Status = 'ATTEND' | 'OFF' | 'IPP' | 'ARMY' | 'COMPLETION' | 'GRADUATE' | '재학' | '휴학' | '현장실습' | '군 휴학' | '수료' | '졸업';
+export type Status = StatusType | StatusLabel;
 export type MemberType = 'BEGINNER' | 'REGULAR' | 'MENTOR';
 
 export const STATUS_LABEL = {

--- a/src/model/member.ts
+++ b/src/model/member.ts
@@ -1,6 +1,8 @@
 import { Track } from './track';
 
 export type StatusType = 'ATTEND' | 'OFF' | 'IPP' | 'ARMY' | 'COMPLETION' | 'GRADUATE';
+export type StatusLabel = '재학' | '휴학' | '현장실습' | '군 휴학' | '수료' | '졸업';
+export type Status = 'ATTEND' | 'OFF' | 'IPP' | 'ARMY' | 'COMPLETION' | 'GRADUATE' | '재학' | '휴학' | '현장실습' | '군 휴학' | '수료' | '졸업';
 export type MemberType = 'BEGINNER' | 'REGULAR' | 'MENTOR';
 
 export const STATUS_LABEL = {
@@ -24,7 +26,7 @@ export interface Member {
   joinedMonth: number;
   track: Track;
   memberType: MemberType;
-  status: StatusType;
+  status: Status;
   name: string;
   company: string;
   department: string;
@@ -45,7 +47,7 @@ export interface AdminMemberUpdate {
   joinedMonth: number;
   trackId: number;
   memberType: MemberType;
-  status: StatusType;
+  status: Status;
   name: string;
   company: string;
   department: string;
@@ -63,7 +65,7 @@ export interface MemberUpdate {
   joinedMonth: number;
   trackId: number;
   memberType: MemberType;
-  status: StatusType;
+  status: Status;
   name: string;
   company: string;
   department: string;

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -93,14 +93,47 @@ export default function GridLayout({ deleteMemberChecked }: ListLayoutProps) {
                       <div css={S.name}>{member.name}</div>
                     </div>
                     <div>
+                      <div css={S.memberInfoLabel}>
+                        상태
+                      </div>
                       {STATUS_LABEL[member.status as keyof typeof STATUS_LABEL]}
                     </div>
-                    <div>{member.memberType}</div>
-                    <div>{member.studentNumber}</div>
-                    <div>{member.company}</div>
-                    <div>{member.department}</div>
-                    <div>{member.phoneNumber}</div>
-                    <div>{member.email}</div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        직책
+                      </div>
+                      {member.memberType}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        학번
+                      </div>
+                      {member.studentNumber}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        소속
+                      </div>
+                      {member.company}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        학부
+                      </div>
+                      {member.department}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        전화번호
+                      </div>
+                      {member.phoneNumber}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        이메일
+                      </div>
+                      {member.email}
+                    </div>
                   </div>
                 </Item>
               </Grid>

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -19,8 +19,6 @@ const Item = styled(Paper)(({ theme }) => ({
   },
 }));
 
-const STATUS_LIST = ['ATTEND', 'OFF', 'IPP', 'ARMY', 'COMPLETION', 'GRADUATE'] as const;
-
 interface ListLayoutProps {
   deleteMemberChecked: boolean;
 }

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -1,9 +1,18 @@
+import { useGetMembers, useGetMembersDeleted } from 'query/members';
+import { useTrackStore } from 'store/trackStore';
+import { Member, STATUS_LABEL } from 'model/member';
+import Grid from '@mui/material/Grid';
 import * as S from './style';
 
 export default function GridLayout() {
+  const { id } = useTrackStore();
+  const { data: members } = useGetMembers({ pageIndex: 0, pageSize: 1000, trackId: id });
+  const { data: membersDeleted } = useGetMembersDeleted({
+    pageIndex: 0, pageSize: 1000, trackId: id,
+  });
   return (
     <div css={S.container}>
-      <div css={S.memberTypeContainer}>MENTOR</div>
+      <div css={S.memberTypeContainer} />
       <div css={S.memberTypeContainer}>REGULAR</div>
       <div css={S.memberTypeContainer}>BEGINNER</div>
     </div>

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -21,7 +21,11 @@ const Item = styled(Paper)(({ theme }) => ({
 
 const STATUS_LIST = ['ATTEND', 'OFF', 'IPP', 'ARMY', 'COMPLETION', 'GRADUATE'] as const;
 
-export default function GridLayout() {
+interface ListLayoutProps {
+  deleteMemberChecked: boolean;
+}
+
+export default function GridLayout({ deleteMemberChecked }: ListLayoutProps) {
   const defaultImageUrl = 'https://image.bcsdlab.com/default-profile.png';
   const { id } = useTrackStore();
   const { data: members } = useGetMembers({ pageIndex: 0, pageSize: 1000, trackId: id });
@@ -46,33 +50,61 @@ export default function GridLayout() {
     <div css={S.container}>
       <div css={S.memberContainer}>
         <Grid container spacing={3}>
-          {members?.content.map((member: Member) => (
-            <Grid item xs={3} key={member.id}>
-              <Item
-                css={S.memberContainer}
-                onClick={() => {
-                  setMemberInfo(member);
-                  handleOpenModal();
-                }}
-              >
-                <div css={S.memberWrapper}>
-                  <div css={S.imageNameWrapper}>
-                    <img css={S.image} src={member.profileImageUrl || defaultImageUrl} alt="profile" />
-                    <div css={S.name}>{member.name}</div>
+          { deleteMemberChecked
+            ? membersDeleted?.content.map((member: Member) => (
+              <Grid item xs={3} key={member.id}>
+                <Item
+                  css={S.memberContainer}
+                  onClick={() => {
+                    setMemberInfo(member);
+                    handleOpenModal();
+                  }}
+                >
+                  <div css={S.memberWrapper}>
+                    <div css={S.imageNameWrapper}>
+                      <img css={S.image} src={member.profileImageUrl || defaultImageUrl} alt="profile" />
+                      <div css={S.name}>{member.name}</div>
+                    </div>
+                    <div>
+                      {STATUS_LABEL[member.status as keyof typeof STATUS_LABEL]}
+                    </div>
+                    <div>{member.memberType}</div>
+                    <div>{member.studentNumber}</div>
+                    <div>{member.company}</div>
+                    <div>{member.department}</div>
+                    <div>{member.phoneNumber}</div>
+                    <div>{member.email}</div>
                   </div>
-                  <div>
-                    {STATUS_LABEL[member.status as keyof typeof STATUS_LABEL]}
+                </Item>
+              </Grid>
+            ))
+            : members?.content.map((member: Member) => (
+              <Grid item xs={3} key={member.id}>
+                <Item
+                  css={S.memberContainer}
+                  onClick={() => {
+                    setMemberInfo(member);
+                    handleOpenModal();
+                  }}
+                >
+                  <div css={S.memberWrapper}>
+                    <div css={S.imageNameWrapper}>
+                      <img css={S.image} src={member.profileImageUrl || defaultImageUrl} alt="profile" />
+                      <div css={S.name}>{member.name}</div>
+                    </div>
+                    <div>
+                      {STATUS_LABEL[member.status as keyof typeof STATUS_LABEL]}
+                    </div>
+                    <div>{member.memberType}</div>
+                    <div>{member.studentNumber}</div>
+                    <div>{member.company}</div>
+                    <div>{member.department}</div>
+                    <div>{member.phoneNumber}</div>
+                    <div>{member.email}</div>
                   </div>
-                  <div>{member.memberType}</div>
-                  <div>{member.studentNumber}</div>
-                  <div>{member.company}</div>
-                  <div>{member.department}</div>
-                  <div>{member.phoneNumber}</div>
-                  <div>{member.email}</div>
-                </div>
-              </Item>
-            </Grid>
-          ))}
+                </Item>
+              </Grid>
+            ))}
         </Grid>
       </div>
       <MemberInfoModal

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -54,7 +54,7 @@ export default function GridLayout() {
                 <div css={S.memberWrapper}>
                   <div css={S.imageNameWrapper}>
                     <img css={S.image} src={member.profileImageUrl || defaultImageUrl} alt="profile" />
-                    <div>{member.name}</div>
+                    <div css={S.name}>{member.name}</div>
                   </div>
                   <div>
                     {STATUS_LABEL[member.status]}

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -2,19 +2,80 @@ import { useGetMembers, useGetMembersDeleted } from 'query/members';
 import { useTrackStore } from 'store/trackStore';
 import { Member, STATUS_LABEL } from 'model/member';
 import Grid from '@mui/material/Grid';
+import { useState } from 'react';
+import MemberInfoModal from 'component/modal/memberInfoModal';
+import { Paper, styled } from '@mui/material';
 import * as S from './style';
 
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+  ':hover': {
+    cursor: 'pointer',
+    boxShadow: theme.shadows[4],
+  },
+}));
+
+const STATUS_LIST = ['ATTEND', 'OFF', 'IPP', 'ARMY', 'COMPLETION', 'GRADUATE'] as const;
+
 export default function GridLayout() {
+  const defaultImageUrl = 'https://image.bcsdlab.com/default-profile.png';
   const { id } = useTrackStore();
   const { data: members } = useGetMembers({ pageIndex: 0, pageSize: 1000, trackId: id });
+  const [modalOpen, setModalOpen] = useState(false);
+  const [memberInfo, setMemberInfo] = useState<Member | null>(null);
   const { data: membersDeleted } = useGetMembersDeleted({
     pageIndex: 0, pageSize: 1000, trackId: id,
   });
+  const handleOpenModal = () => {
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+  };
+
   return (
     <div css={S.container}>
-      <div css={S.memberTypeContainer} />
-      <div css={S.memberTypeContainer}>REGULAR</div>
-      <div css={S.memberTypeContainer}>BEGINNER</div>
+      <div css={S.memberContainer}>
+        <Grid container spacing={3}>
+          {members?.content.map((member: Member) => (
+            <Grid item xs={3} key={member.id}>
+              <Item
+                css={S.memberContainer}
+                onClick={() => {
+                  setMemberInfo(member);
+                  handleOpenModal();
+                }}
+              >
+                <div css={S.memberWrapper}>
+                  <div css={S.imageNameWrapper}>
+                    <img css={S.image} src={member.profileImageUrl || defaultImageUrl} alt="profile" />
+                    <div>{member.name}</div>
+                  </div>
+                  <div>
+                    {STATUS_LABEL[member.status]}
+                  </div>
+                  <div>{member.memberType}</div>
+                  <div>{member.studentNumber}</div>
+                  <div>{member.company}</div>
+                  <div>{member.department}</div>
+                  <div>{member.phoneNumber}</div>
+                  <div>{member.email}</div>
+                </div>
+              </Item>
+            </Grid>
+          ))}
+        </Grid>
+      </div>
+      <MemberInfoModal
+        open={modalOpen}
+        onClose={handleCloseModal}
+        member={memberInfo}
+      />
     </div>
 
   );

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -64,14 +64,47 @@ export default function GridLayout({ deleteMemberChecked }: ListLayoutProps) {
                       <div css={S.name}>{member.name}</div>
                     </div>
                     <div>
+                      <div css={S.memberInfoLabel}>
+                        상태
+                      </div>
                       {STATUS_LABEL[member.status as keyof typeof STATUS_LABEL]}
                     </div>
-                    <div>{member.memberType}</div>
-                    <div>{member.studentNumber}</div>
-                    <div>{member.company}</div>
-                    <div>{member.department}</div>
-                    <div>{member.phoneNumber}</div>
-                    <div>{member.email}</div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        직책
+                      </div>
+                      {member.memberType}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        학번
+                      </div>
+                      {member.studentNumber}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        소속
+                      </div>
+                      {member.company}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        학부
+                      </div>
+                      {member.department}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        전화번호
+                      </div>
+                      {member.phoneNumber}
+                    </div>
+                    <div>
+                      <div css={S.memberInfoLabel}>
+                        이메일
+                      </div>
+                      {member.email}
+                    </div>
                   </div>
                 </Item>
               </Grid>

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -61,7 +61,7 @@ export default function GridLayout() {
                     <div css={S.name}>{member.name}</div>
                   </div>
                   <div>
-                    {STATUS_LABEL[member.status]}
+                    {STATUS_LABEL[member.status as keyof typeof STATUS_LABEL]}
                   </div>
                   <div>{member.memberType}</div>
                   <div>{member.studentNumber}</div>
@@ -79,6 +79,7 @@ export default function GridLayout() {
         open={modalOpen}
         onClose={handleCloseModal}
         member={memberInfo}
+        isList={false}
       />
     </div>
 

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -1,4 +1,4 @@
-import { useGetMembers, useGetMembersDeleted } from 'query/members';
+import { useGetMe, useGetMembers, useGetMembersDeleted } from 'query/members';
 import { useTrackStore } from 'store/trackStore';
 import { Member, STATUS_LABEL } from 'model/member';
 import Grid from '@mui/material/Grid';
@@ -30,8 +30,12 @@ export default function GridLayout() {
   const { data: membersDeleted } = useGetMembersDeleted({
     pageIndex: 0, pageSize: 1000, trackId: id,
   });
+  const { data: getMe } = useGetMe();
+
   const handleOpenModal = () => {
-    setModalOpen(true);
+    if (getMe.authority === 'ADMIN' || getMe.authority === 'MANAGER') {
+      setModalOpen(true);
+    }
   };
 
   const handleCloseModal = () => {

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -137,6 +137,13 @@ export default function GridLayout({ deleteMemberChecked }: ListLayoutProps) {
                     </div>
                     <div>
                       <div css={S.memberInfoLabel}>
+                        트랙
+                      </div>
+                      {member.track.name}
+                    </div>
+
+                    <div>
+                      <div css={S.memberInfoLabel}>
                         학번
                       </div>
                       {member.studentNumber}

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -1,5 +1,12 @@
+import * as S from './style';
+
 export default function GridLayout() {
   return (
-    <div>그리드 레이아웃</div>
+    <div css={S.container}>
+      <div css={S.memberTypeContainer}>MENTOR</div>
+      <div css={S.memberTypeContainer}>REGULAR</div>
+      <div css={S.memberTypeContainer}>BEGINNER</div>
+    </div>
+
   );
 }

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -15,14 +15,15 @@ export const memberContainer = css`
 `;
 
 export const memberWrapper = css`
-  width: 300px;
-  height: 380px;
+  width: 280px;
+  height: 370px;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  padding-top: 20px;
+  padding-top: 10px;
   gap: 15px;
+  font-size: 15px;
 `;
 
 export const imageNameWrapper = css`
@@ -31,10 +32,19 @@ export const imageNameWrapper = css`
   display: flex;
   justify-content: space-around;
   align-items: center;
+  margin-top: 10px;
+  position: relative;
 `;
 
 export const image = css`
   width: 50%;
   height: 100%;
   object-fit: scale-down;
+`;
+
+export const name = css`
+  font-size: 25px;
+  font-weight: bold;
+  color: #000;
+  margin-right: 30px;
 `;

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -1,0 +1,14 @@
+import { css } from '@emotion/react';
+
+export const container = css`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+export const memberTypeContainer = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -6,9 +6,35 @@ export const container = css`
   gap: 20px;
 `;
 
-export const memberTypeContainer = css`
+export const memberContainer = css`
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 10px;
+  margin: 10px 10px 0 10px;
+`;
+
+export const memberWrapper = css`
+  width: 300px;
+  height: 380px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding-top: 20px;
+  gap: 15px;
+`;
+
+export const imageNameWrapper = css`
+  width: 100%;
+  height: 100px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+export const image = css`
+  width: 50%;
+  height: 100%;
+  object-fit: scale-down;
 `;

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -1,4 +1,5 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
 
 export const container = css`
   display: flex;
@@ -16,12 +17,13 @@ export const memberContainer = css`
 
 export const memberWrapper = css`
   width: 280px;
-  height: 370px;
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   padding-top: 10px;
+  padding-bottom: 10px;
   gap: 15px;
   font-size: 15px;
 `;
@@ -47,4 +49,12 @@ export const name = css`
   font-weight: bold;
   color: #000;
   margin-right: 30px;
+`;
+
+export const memberInfoLabel = css`
+  font-weight: bold;
+  display: inline-block;
+  justify-content: flex-start;
+  width: 60px;
+  margin-right: 10px;
 `;

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -30,11 +30,10 @@ export const memberWrapper = css`
 
 export const imageNameWrapper = css`
   width: 100%;
-  height: 100px;
+  height: 120px;
   display: flex;
   justify-content: space-around;
   align-items: center;
-  margin-top: 10px;
   position: relative;
 `;
 

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -12,6 +12,7 @@ export const memberContainer = css`
   align-items: center;
   gap: 10px;
   margin: 10px 10px 0 10px;
+  border-radius: 10px;
 `;
 
 export const memberWrapper = css`

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -1,5 +1,4 @@
-import { css, keyframes } from '@emotion/react';
-import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 export const container = css`
   display: flex;

--- a/src/page/MemberInfo/ListLayout/index.tsx
+++ b/src/page/MemberInfo/ListLayout/index.tsx
@@ -69,13 +69,13 @@ export default function ListLayout({ deleteMemberChecked }: ListLayoutProps) {
             deleteMemberChecked
               ? membersDeleted.content.map((member) => ({
                 ...member,
-                status: STATUS_LABEL[member.status],
+                status: STATUS_LABEL[member.status as keyof typeof STATUS_LABEL],
                 trackName: member.track.name,
                 track: member.track,
               }))
               : members.content.map((member) => ({
                 ...member,
-                status: STATUS_LABEL[member.status],
+                status: STATUS_LABEL[member.status as keyof typeof STATUS_LABEL],
                 trackName: member.track.name,
                 track: member.track,
               }))
@@ -93,6 +93,7 @@ export default function ListLayout({ deleteMemberChecked }: ListLayoutProps) {
         open={modalOpen}
         onClose={handleCloseModal}
         member={memberInfo}
+        isList={true}
       />
     </div>
   );

--- a/src/page/MemberInfo/index.tsx
+++ b/src/page/MemberInfo/index.tsx
@@ -39,16 +39,6 @@ export default function MemberInfo() {
       </div>
       <div>
         <div css={S.buttonContainer}>
-          {memberAuthority === ('ADMIN' || 'MANAGER') && (
-          <Button
-            variant="outlined"
-            color="primary"
-            startIcon={<AddIcon />}
-            onClick={handleOpenMemberCreateModal}
-          >
-            생성
-          </Button>
-          )}
           <FormControlLabel control={<Switch checked={deleteMemberChecked} onChange={handleChangedDeleteMember} />} label="탈퇴 회원" />
           <Suspense fallback={<div />}>
             <TrackFilter />

--- a/src/page/MemberInfo/index.tsx
+++ b/src/page/MemberInfo/index.tsx
@@ -65,16 +65,18 @@ export default function MemberInfo() {
             {layout === 'list' ? <ListLayout deleteMemberChecked={deleteMemberChecked} /> : <GridLayout />}
           </Suspense>
           <div css={S.createButtonContainer}>
-            <div css={S.createButton}>
-              <Button
-                variant="outlined"
-                color="primary"
-                startIcon={<AddIcon />}
-                onClick={handleOpenMemberCreateModal}
-              >
-                회원 생성
-              </Button>
-            </div>
+            {memberAuthority === 'ADMIN' || memberAuthority === 'MANAGER' ? (
+              <div css={S.createButton}>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<AddIcon />}
+                  onClick={handleOpenMemberCreateModal}
+                >
+                  회원 생성
+                </Button>
+              </div>
+            ) : <div />}
           </div>
         </div>
         <MemberCreateModal

--- a/src/page/MemberInfo/index.tsx
+++ b/src/page/MemberInfo/index.tsx
@@ -62,7 +62,7 @@ export default function MemberInfo() {
         </div>
         <div css={S.viewContent}>
           <Suspense fallback={<div />}>
-            {layout === 'list' ? <ListLayout deleteMemberChecked={deleteMemberChecked} /> : <GridLayout />}
+            {layout === 'list' ? <ListLayout deleteMemberChecked={deleteMemberChecked} /> : <GridLayout deleteMemberChecked={deleteMemberChecked} />}
           </Suspense>
           <div css={S.createButtonContainer}>
             {memberAuthority === 'ADMIN' || memberAuthority === 'MANAGER' ? (

--- a/src/page/MemberInfo/style.ts
+++ b/src/page/MemberInfo/style.ts
@@ -22,6 +22,7 @@ export const topBar = css`
   background-color: ${color.gray};
   border-bottom: 1px solid ${color.borderGray};
   box-sizing: border-box;
+  flex-shrink: 0;
 `;
 
 export const topBarTitle = css`


### PR DESCRIPTION
## [#55 ] request

- 그리드 레이아웃으로 회원정보를 조회할 수 있도록 구현했습니다.
- 각 그리드 컨테이너를 눌러 회원정보를 수정할 수 있습니다(admin, manager 권한을 가진경우)

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot
<img width="1906" alt="스크린샷 2024-03-02 오전 4 15 35" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/42c9fb3e-55ae-485f-8b9c-c522998a6e14">
<img width="1916" alt="스크린샷 2024-03-02 오전 4 15 46" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/aee8afc9-c681-4fd1-9c89-28c435a99bf6">


### Precautions (main files for this PR ...)

- Close #55 
