### PR TITLE
[비밀번호 찾기] 비밀번호 찾기 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,14 @@ import MyPage from 'page/MyPage';
 import DuesSetup from 'page/DuesSetup';
 import EditDues from 'page/EditDues';
 import LoadingSpinner from 'layout/LoadingSpinner';
+import FindPassword from 'page/FindPassword';
 
 function App() {
   return (
     <Routes>
       <Route element={<AuthRoute needAuth={false} redirectRoute="/member" />}>
         <Route path="/" element={<SignIn />} />
+        <Route path="/find-password" element={<FindPassword />} />
       </Route>
       <Route
         path="/register"

--- a/src/api/members/index.ts
+++ b/src/api/members/index.ts
@@ -1,6 +1,7 @@
 import { accessClient } from 'api';
 import {
   AdminMemberUpdate, LoginResponse, Member, MemberCreate, MemberResponse, MemberUpdate,
+  CertificationToken, RequestChangePassword, ChangePassword,
 } from 'model/member';
 import { Pagination } from 'model/page';
 
@@ -37,3 +38,10 @@ export const getNotAuthedMembers = () => accessClient.get<MemberResponse>('/memb
 export const getMe = () => accessClient.get<Member>('/members/me');
 
 export const updateMe = (member: MemberUpdate) => accessClient.put<Member>('/members', member);
+
+// response body가 없는 api
+export const requestChangePassword = (email: RequestChangePassword) => accessClient.post('/members/password/change', email);
+
+export const certificationToken = (info: CertificationToken) => accessClient.post('/members/password/certification', info);
+
+export const changePassword = (info: ChangePassword) => accessClient.post('/members/password', info);

--- a/src/api/members/index.ts
+++ b/src/api/members/index.ts
@@ -33,7 +33,7 @@ export const createMember = (member: MemberCreate) => {
 
 export const login = (studentNumber: string, password: string) => accessClient.post<LoginResponse>('/members/login', { studentNumber, password });
 
-export const getNotAuthedMembers = () => accessClient.get<MemberResponse>('/members?authed=false');
+export const getNotAuthedMembers = () => accessClient.get<MemberResponse>('/members?authed=false&size=1000&page=0');
 
 export const getMe = () => accessClient.get<Member>('/members/me');
 

--- a/src/model/member.ts
+++ b/src/model/member.ts
@@ -155,3 +155,19 @@ export type LoginResponse = {
 export interface MemberResponse {
   content: Member[];
 }
+
+export interface RequestChangePassword {
+  email: string;
+}
+
+export interface CertificationToken extends RequestChangePassword {
+  token: string;
+}
+
+export interface ChangePassword extends CertificationToken {
+  password: string;
+}
+
+export interface ChangePasswordForm extends ChangePassword {
+  passwordCheck: string;
+}

--- a/src/page/FindPassword/index.tsx
+++ b/src/page/FindPassword/index.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import { Button, TextField } from '@mui/material';
+import {
+  ChangePasswordForm, RequestChangePassword, CertificationToken, ChangePassword,
+} from 'model/member';
+import { requestChangePassword, certificationToken, changePassword } from 'api/members';
+import { SHA256 } from 'crypto-js';
+import { useSnackBar } from 'ts/useSnackBar';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+import * as S from './style';
+
+const initialState = {
+  email: '',
+  token: '',
+  password: '',
+  passwordCheck: '',
+};
+
+interface Step {
+  email: boolean,
+  token: boolean,
+  password: boolean,
+}
+
+const initialStep = {
+  email: true,
+  token: false,
+  password: false,
+};
+
+export default function FindPassword() {
+  const [passwordChangeInfo, setPasswordChangeInfo] = useState<ChangePasswordForm>(initialState);
+  const [step, setStep] = useState<Step>(initialStep);
+  const openSnackBar = useSnackBar();
+  const navigate = useNavigate();
+
+  const handleEmailInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPasswordChangeInfo({ ...passwordChangeInfo, email: e.target.value });
+  };
+
+  const handleTokenInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPasswordChangeInfo({ ...passwordChangeInfo, token: e.target.value });
+  };
+
+  const handlePasswordInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPasswordChangeInfo({ ...passwordChangeInfo, password: e.target.value });
+  };
+
+  const handlePasswordCheckInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPasswordChangeInfo({ ...passwordChangeInfo, passwordCheck: e.target.value });
+  };
+
+  const requestEamil = async (email: RequestChangePassword) => {
+    try {
+      await requestChangePassword(email);
+      setStep({ ...step, token: true });
+    } catch (e) {
+      if (e instanceof AxiosError) openSnackBar({ type: 'error', message: e.response?.data.message });
+    }
+  };
+
+  const certification = async (info: CertificationToken) => {
+    try {
+      await certificationToken(info);
+      setStep({ ...step, password: true });
+    } catch (e) {
+      if (e instanceof AxiosError) openSnackBar({ type: 'error', message: e.response?.data.message });
+    }
+  };
+
+  const change = async (info: ChangePassword) => {
+    try {
+      if (info.password === passwordChangeInfo.passwordCheck) {
+        await changePassword({
+          email: info.email,
+          token: info.token,
+          password: SHA256(info.password).toString(),
+        });
+        openSnackBar({ type: 'success', message: '비밀번호를 성공적으로 변경했습니다.' });
+        navigate('/');
+      } else {
+        openSnackBar({ type: 'error', message: '비밀번호가 일치하지 않습니다.' });
+      }
+    } catch (e) {
+      if (e instanceof AxiosError) openSnackBar({ type: 'error', message: e.response?.data.message });
+    }
+  };
+
+  const changePasswordStep = () => {
+    if (step.password) {
+      change({
+        email: passwordChangeInfo.email,
+        token: passwordChangeInfo.token,
+        password: passwordChangeInfo.password,
+      });
+    } else if (step.token) {
+      certification({
+        email: passwordChangeInfo.email,
+        token: passwordChangeInfo.token,
+      });
+    } else requestEamil({ email: passwordChangeInfo.email });
+  };
+
+  return (
+    <div css={S.layout}>
+      <div css={S.container}>
+        <img src="https://image.bcsdlab.com/banner.png" alt="bscd logo" css={S.image} />
+        <p css={S.font}>
+          {!step.password && !step.token && step.email && '가입하실 때 사용한 이메일을 입력해 주세요.'}
+          {!step.password && step.token && '인증번호를 입력해 주세요.'}
+          {step.password && '변경하실 비밀번호를 입력해 주세요.'}
+        </p>
+        <div css={S.inputSet}>
+          <TextField
+            label="email"
+            variant="outlined"
+            value={passwordChangeInfo.email}
+            onChange={handleEmailInput}
+            disabled={step.token}
+          />
+          {step.token
+            && (
+              <TextField
+                label="인증번호"
+                variant="outlined"
+                value={passwordChangeInfo.token}
+                onChange={handleTokenInput}
+                disabled={step.password}
+              />
+            )}
+          {step.password
+            && (
+              <TextField
+                label="새 비밀번호"
+                variant="outlined"
+                value={passwordChangeInfo.password}
+                onChange={handlePasswordInput}
+              />
+            )}
+          {step.password
+            && (
+              <TextField
+                label="새 비밀번호 확인"
+                variant="outlined"
+                value={passwordChangeInfo.passwordCheck}
+                onChange={handlePasswordCheckInput}
+              />
+            )}
+        </div>
+        <Button
+          variant="contained"
+          onClick={changePasswordStep}
+          css={S.button}
+        >
+          {step.password ? '변경' : '다음'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/page/FindPassword/index.tsx
+++ b/src/page/FindPassword/index.tsx
@@ -136,6 +136,7 @@ export default function FindPassword() {
                 variant="outlined"
                 value={passwordChangeInfo.password}
                 onChange={handlePasswordInput}
+                type="password"
               />
             )}
           {step.password
@@ -145,6 +146,7 @@ export default function FindPassword() {
                 variant="outlined"
                 value={passwordChangeInfo.passwordCheck}
                 onChange={handlePasswordCheckInput}
+                type="password"
               />
             )}
         </div>

--- a/src/page/FindPassword/style.ts
+++ b/src/page/FindPassword/style.ts
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react';
+import { colors } from 'const/colors/style';
+
+export const layout = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+`;
+
+export const container = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 500px;
+  height: 650px;
+  border: 1px solid ${colors.borderGray};
+  background-color: white;
+  position: relative;
+`;
+
+export const inputSet = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 250px;
+  height: calc(650px - 325px);
+  gap: 10px;
+`;
+
+export const button = css`
+  width: 150px;
+  height: 35px;
+  margin-bottom: 20px;
+`;
+
+export const image = css`
+  width: 400px;
+  height: 251.144px;
+  object-fit: fill;
+`;
+
+export const font = css`
+  position: fixed;
+  top: 260px;
+  font-weight: bold;
+  height: 20px;
+`;

--- a/src/page/SignIn/index.tsx
+++ b/src/page/SignIn/index.tsx
@@ -6,7 +6,7 @@ import {
   TextField, Button, InputAdornment, OutlinedInput, IconButton, FormControl, InputLabel, Paper,
 } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import * as S from './style';
 
 const DemoPaper = styled(Paper)(({ theme }) => ({
@@ -89,6 +89,7 @@ export default function SignIn() {
               회원가입
             </Button>
           </div>
+          <Link to="find-password" css={S.Link}>비밀번호를 잊으셨나요?</Link>
         </form>
       </DemoPaper>
     </div>

--- a/src/page/SignIn/style.ts
+++ b/src/page/SignIn/style.ts
@@ -28,3 +28,8 @@ export const image = css`
 export const input = css`
   width: 200px;
 `;
+
+export const Link = css`
+  text-decoration: none;
+  color: black;
+`;


### PR DESCRIPTION
## [#83 ] 비밀번호 찾기 페이지 구현

비밀번호 찾기 페이지는 비밀번호를 변경하는 방식으로 동작합니다.

이메일, 인증번호, 새 비밀번호를 단계에 맞게 입력하고
요청이 성공하면 비밀번호가 변경되며 로그인 화면으로 이동합니다.

추가적으로 회원가입 승인 페이지에 페이지네이션을 적용했습니다.

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/101871802/0009fe32-db6f-4254-b279-a7be1cfcab9d)
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/101871802/717d902a-5abc-43e3-b9ac-580fac5dafa0)
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/101871802/880f8c59-7d0a-47b3-9b66-81f728a768a4)
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/101871802/656fe46b-770d-437d-b636-5f234ad0ff98)

### Precautions (main files for this PR ...)

- Close #83 
- Close #72 
