### PR TITLE
[공통] 사이드바 회비 그룹 생성 및 스타일 수정

### DIFF
--- a/src/layout/SideBar/index.tsx
+++ b/src/layout/SideBar/index.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { KeyboardDoubleArrowDown, KeyboardDoubleArrowUp } from '@mui/icons-material';
+import { pagePath } from 'layout/TopBar';
 import * as S from './style';
 
 export default function SideBar() {
@@ -11,24 +12,80 @@ export default function SideBar() {
     navigate('/');
   };
   const [isClicked, setIsClicked] = useState(false);
+  const location = useLocation();
+  const currentPage = pagePath.filter((path) => location.pathname === path.path)[0].path;
 
   return (
     <div css={S.container}>
       <div css={S.sideBar}>
         <img src="https://image.bcsdlab.com/banner.png" alt="logo" css={S.logo} />
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('member')} css={S.button('20px')}>회원 정보</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('mypage')} css={S.button('60px')}>마이페이지</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('accept')} css={S.button('100px')}>회원 승인</Button>
-        <Button variant="outlined" color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => setIsClicked((prev) => !prev)} css={S.duesButton}>
+        <Button
+          color="secondary"
+          sx={{ marginTop: '20px' }}
+          size="large"
+          onClick={() => navigate('member')}
+          css={S.button(currentPage === '/member')}
+        >
+          회원 정보
+        </Button>
+        <Button
+          color="secondary"
+          sx={{ marginTop: '20px' }}
+          size="large"
+          onClick={() => navigate('mypage')}
+          css={S.button(currentPage === '/mypage')}
+        >
+          마이페이지
+        </Button>
+        <Button
+          color="secondary"
+          sx={{ marginTop: '20px' }}
+          size="large"
+          onClick={() => navigate('accept')}
+          css={S.button(currentPage === '/accept')}
+        >
+          회원 승인
+        </Button>
+        <Button
+          color="secondary"
+          sx={{ marginTop: '20px' }}
+          size="large"
+          onClick={() => setIsClicked((prev) => !prev)}
+          css={S.duesButton}
+        >
           회비
           {isClicked ? <KeyboardDoubleArrowUp /> : <KeyboardDoubleArrowDown />}
         </Button>
         {
           isClicked && (
             <div css={S.duesGroup}>
-              <Button color="primary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues')} css={S.button('140px')}>납부 내역</Button>
-              <Button color="primary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues-setup')} css={S.button('180px')}>회비 생성</Button>
-              <Button color="primary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('edit-dues')} css={S.button('220px')}>회비 수정</Button>
+              <Button
+                color="secondary"
+                sx={{ marginTop: '20px' }}
+                size="large"
+                onClick={() => navigate('dues')}
+                css={S.button(currentPage === '/dues')}
+              >
+                납부 내역
+              </Button>
+              <Button
+                color="secondary"
+                sx={{ marginTop: '20px' }}
+                size="large"
+                onClick={() => navigate('dues-setup')}
+                css={S.button(currentPage === '/dues-setup')}
+              >
+                회비 생성
+              </Button>
+              <Button
+                color="secondary"
+                sx={{ marginTop: '20px' }}
+                size="large"
+                onClick={() => navigate('edit-dues')}
+                css={S.button(currentPage === '/edit-dues')}
+              >
+                회비 수정
+              </Button>
             </div>
           )
         }

--- a/src/layout/SideBar/index.tsx
+++ b/src/layout/SideBar/index.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { KeyboardDoubleArrowDown, KeyboardDoubleArrowUp } from '@mui/icons-material';
 import * as S from './style';
 
 export default function SideBar() {
@@ -8,19 +10,30 @@ export default function SideBar() {
     localStorage.removeItem('accessToken');
     navigate('/');
   };
+  const [isClicked, setIsClicked] = useState(false);
 
   return (
     <div css={S.container}>
       <div css={S.sideBar}>
         <img src="https://image.bcsdlab.com/banner.png" alt="logo" css={S.logo} />
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('member')} css={S.button('20px')}>회원정보</Button>
+        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('member')} css={S.button('20px')}>회원 정보</Button>
         <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('mypage')} css={S.button('60px')}>마이페이지</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('accept')} css={S.button('100px')}>회원승인</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues')} css={S.button('140px')}>회비납부</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues-setup')} css={S.button('180px')}>회비생성</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('edit-dues')} css={S.button('220px')}>회비수정</Button>
+        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('accept')} css={S.button('100px')}>회원 승인</Button>
+        <Button variant="outlined" color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => setIsClicked((prev) => !prev)} css={S.duesButton}>
+          회비
+          {isClicked ? <KeyboardDoubleArrowUp /> : <KeyboardDoubleArrowDown />}
+        </Button>
+        {
+          isClicked && (
+            <div css={S.duesGroup}>
+              <Button color="primary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues')} css={S.button('140px')}>납부 내역</Button>
+              <Button color="primary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('dues-setup')} css={S.button('180px')}>회비 생성</Button>
+              <Button color="primary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('edit-dues')} css={S.button('220px')}>회비 수정</Button>
+            </div>
+          )
+        }
         <div css={S.logOutButton}>
-          <Button variant="contained" color="secondary" sx={{ marginTop: '20vh', width: '100px' }} onClick={logOut}>로그아웃</Button>
+          <Button variant="contained" color="secondary" sx={{ width: '100px' }} onClick={logOut}>로그아웃</Button>
         </div>
       </div>
     </div>

--- a/src/layout/SideBar/style.ts
+++ b/src/layout/SideBar/style.ts
@@ -41,9 +41,8 @@ export const logOutButton = css`
   left: 50px;
 `;
 
-export const button = (props: string) => css`
-  position: sticky;
-  top: ${props};
+export const button = (props: boolean) => css`
+  background-color: ${props ? '#ffeeff' : 'none'};
 `;
 
 export const duesButton = () => css`

--- a/src/layout/SideBar/style.ts
+++ b/src/layout/SideBar/style.ts
@@ -36,12 +36,23 @@ export const logo = css`
 `;
 
 export const logOutButton = css`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  position: absolute;
+  bottom: 30px;
+  left: 50px;
 `;
 
 export const button = (props: string) => css`
   position: sticky;
   top: ${props};
+`;
+
+export const duesButton = () => css`
+  display: flex;
+  align-items: center;
+`;
+
+export const duesGroup = css`
+  display: flex;
+  flex-direction: column;
+
 `;

--- a/src/layout/TopBar/index.tsx
+++ b/src/layout/TopBar/index.tsx
@@ -2,7 +2,7 @@ import { useLocation } from 'react-router-dom';
 import useQueryParam from 'util/hooks/useQueryParam';
 import * as S from './style';
 
-const pagePath = [
+export const pagePath = [
   {
     path: '/accept',
     title: '회원가입 승인',
@@ -17,7 +17,7 @@ const pagePath = [
   },
   {
     path: '/dues',
-    title: '회비 내역',
+    title: '회비 납부 내역',
   },
   {
     path: '/dues-setup',


### PR DESCRIPTION
## [#65 #66 ] request

사이드바에 회비 그룹을 만들어서 회비 버튼 클릭시 회비 관리 리스트가 보이도록 변경했습니다.

pr에 올려주신 내용을 참고하여 현재 위치한 페이지의 버튼에 background-color를 변경했습니다.
## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/101871802/0f856543-f64b-402e-80f1-acd7cdb0a0c4)
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/101871802/e8c51607-c132-4ccd-b4fa-1d80ca61ef27)

### Precautions (main files for this PR ...)

- Close #65 
- Close #66 
