### PR TITLE
2차 스프린트 UI 이슈 해결

### DIFF
--- a/src/page/Admin/index.tsx
+++ b/src/page/Admin/index.tsx
@@ -40,7 +40,7 @@ export default function AcceptMember() {
   return (
     <div css={S.container}>
       <div style={{
-        height: '70vh', paddingLeft: 20, paddingRight: 20,
+        height: '70vh', paddingLeft: 20, paddingRight: 20, paddingTop: 30,
       }}
       >
         <DataGrid

--- a/src/page/MemberInfo/GridLayout/index.tsx
+++ b/src/page/MemberInfo/GridLayout/index.tsx
@@ -175,7 +175,7 @@ export default function GridLayout({ deleteMemberChecked }: ListLayoutProps) {
                       <div css={S.memberInfoLabel}>
                         이메일
                       </div>
-                      {member.email}
+                      <div css={S.memberInfoLabelSmall}>{member.email}</div>
                     </div>
                   </div>
                 </Item>

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -60,5 +60,5 @@ export const memberInfoLabel = css`
 
 export const memberInfoLabelSmall = css`
   display: inline-block;
-  font-size: 14px;
+  font-size: 13px;
 `;

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -16,7 +16,7 @@ export const memberContainer = css`
 `;
 
 export const memberWrapper = css`
-  width: 280px;
+  width: 100%;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/page/MemberInfo/GridLayout/style.ts
+++ b/src/page/MemberInfo/GridLayout/style.ts
@@ -22,10 +22,10 @@ export const memberWrapper = css`
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  gap: 15px;
+  padding: 10px;
+  gap: 13px;
   font-size: 15px;
+  flex-shrink: 0;
 `;
 
 export const imageNameWrapper = css`
@@ -56,4 +56,9 @@ export const memberInfoLabel = css`
   justify-content: flex-start;
   width: 60px;
   margin-right: 10px;
+`;
+
+export const memberInfoLabelSmall = css`
+  display: inline-block;
+  font-size: 14px;
 `;

--- a/src/page/MemberInfo/ListLayout/index.tsx
+++ b/src/page/MemberInfo/ListLayout/index.tsx
@@ -42,7 +42,7 @@ export default function ListLayout({ deleteMemberChecked }: ListLayoutProps) {
     {
       field: 'update',
       headerName: (memberAuthority === 'ADMIN') || (memberAuthority === 'MANAGER') ? '정보수정' : '',
-      width: (memberAuthority === 'ADMIN') || (memberAuthority === 'MANAGER') ? 100 : 0,
+      width: (memberAuthority === 'ADMIN') || (memberAuthority === 'MANAGER') ? 120 : 0,
       renderCell: (data) => (
         ((memberAuthority === 'ADMIN') || (memberAuthority === 'MANAGER')) && (
         <Button

--- a/src/page/MemberInfo/index.tsx
+++ b/src/page/MemberInfo/index.tsx
@@ -36,7 +36,6 @@ export default function MemberInfo() {
     <div css={S.container}>
       <div>
         <div css={S.buttonContainer}>
-          <FormControlLabel control={<Switch checked={deleteMemberChecked} onChange={handleChangedDeleteMember} />} label="탈퇴 회원" />
           <Suspense fallback={<div />}>
             <TrackFilter />
           </Suspense>
@@ -62,6 +61,7 @@ export default function MemberInfo() {
             {layout === 'list' ? <ListLayout deleteMemberChecked={deleteMemberChecked} /> : <GridLayout deleteMemberChecked={deleteMemberChecked} />}
           </Suspense>
           <div css={S.createButtonContainer}>
+            <FormControlLabel control={<Switch checked={deleteMemberChecked} onChange={handleChangedDeleteMember} />} label="탈퇴 회원" />
             {memberAuthority === 'ADMIN' || memberAuthority === 'MANAGER' ? (
               <div css={S.createButton}>
                 <Button

--- a/src/page/MemberInfo/style.ts
+++ b/src/page/MemberInfo/style.ts
@@ -83,4 +83,8 @@ export const createButtonContainer = css`
 export const createButton = css`
   width: 130px;
   height: 65px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 10px;
 `;

--- a/src/page/SignUp/index.tsx
+++ b/src/page/SignUp/index.tsx
@@ -272,7 +272,7 @@ export default function SignUp() {
           render={({ field }) =>
             <TextField
               select
-              label="학적"
+              label="학적상태"
               variant="outlined"
               fullWidth
               {...field}
@@ -317,7 +317,7 @@ export default function SignUp() {
           render={({ field }) =>
             <TextField
               select
-              label="멤버"
+              label="직위"
               variant="outlined"
               fullWidth
               {...field}
@@ -384,7 +384,7 @@ export default function SignUp() {
           }}
           render={({ field }) =>
             <TextField
-              label="부서"
+              label="학부"
               variant="outlined"
               helperText='ex) 컴퓨터공학부'
               fullWidth
@@ -424,7 +424,7 @@ export default function SignUp() {
           }}
           render={({ field }) =>
             <TextField
-              label="깃허브 이름"
+              label="깃허브 아이디"
               variant="outlined"
               fullWidth
               {...field}


### PR DESCRIPTION
## [#98 #99 #101 #104] request

- 회원승인 페이지 상단 margin 추가
- 회원정보 페이지에서 탈퇴 회원 토글을 하단으로 이동하여 트랙 정보 width 여유공간 제공
- 회원정보 그리드레이아웃에서 이메일 폰트크기를 줄이고, padding을 줄여 더 많은 정보를 한줄에 제공
- 회원가입 페이지에서 label을 다른 페이지들과 통일

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot
<img width="50%" alt="스크린샷 2024-03-18 오전 4 02 43" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/476973c1-3e36-44bf-9b41-8389c71b444a">
<img width="49%" alt="스크린샷 2024-03-18 오전 4 03 20" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/40b96b0c-0846-42d8-8546-ba58423ea958">
<img width="49%" alt="스크린샷 2024-03-18 오전 4 03 34" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/de8ffe4f-d049-4608-ac9d-7f599c45913e">


### Precautions (main files for this PR ...)

- Close #98
- Close #99 
- Close #101 
- Close #104
