### PR TITLE
[회비] 회비 페이지 멘토 인원 삭제

### DIFF
--- a/src/page/DuesManagement/index.tsx
+++ b/src/page/DuesManagement/index.tsx
@@ -30,7 +30,6 @@ function DefaultTable() {
   const page = useQueryParam('page', 'number') as number | null;
   const currentYear = new Date().getFullYear();
   const [duesYear, setDuesYear] = useState(page ? currentYear - page + 1 : currentYear);
-  const [trackFilter, setTrackFilter] = useState([true, true, true, true, true, true]);
   const [name, setName] = useState('');
   const [detail, setDetail] = useState<DuesDetail>({ month: 0, status: null });
   const [memoAnchorEl, setMemoAnchorEl] = useState<null | HTMLElement>(null);
@@ -46,6 +45,7 @@ function DefaultTable() {
   const [filteredValue, setFilteredValue] = useState(allDues.dues);
 
   const { data: tracks } = useGetTracks();
+  const [trackFilter, setTrackFilter] = useState(tracks.map(() => true));
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const searchName = e.target.value;

--- a/src/page/EditDues/index.tsx
+++ b/src/page/EditDues/index.tsx
@@ -35,7 +35,6 @@ function DefaultTable() {
   const page = useQueryParam('page', 'number') as number | null;
   const currentYear = new Date().getFullYear();
   const [duesYear, setDuesYear] = useState(page ? currentYear - page + 1 : currentYear);
-  const [trackFilter, setTrackFilter] = useState([true, true, true, true, true, true]);
   const [name, setName] = useState('');
   const {
     value: isFilterModalOpen,
@@ -63,6 +62,7 @@ function DefaultTable() {
   const [filteredValue, setFilteredValue] = useState(allDues.dues);
 
   const { data: tracks } = useGetTracks();
+  const [trackFilter, setTrackFilter] = useState(tracks.map(() => true));
   const postDuesMutation = usePostDues();
   const putDuesMutation = usePutDues();
   const deleteDuesMutation = useDeleteDues();

--- a/src/page/EditDues/index.tsx
+++ b/src/page/EditDues/index.tsx
@@ -26,6 +26,7 @@ import useQueryParam from 'util/hooks/useQueryParam';
 import { useSnackBar } from 'ts/useSnackBar';
 import makeNumberArray from 'util/hooks/makeNumberArray';
 import { NewDuesData } from 'api/dues';
+import { useGetMembers } from 'query/members';
 import * as S from './style';
 
 type Status = 'PAID' | 'NOT_PAID' | 'SKIP' | 'NONE';
@@ -59,7 +60,8 @@ function DefaultTable() {
   const openSnackBar = useSnackBar();
 
   const { data: allDues, refetch } = useGetAllDues({ year: duesYear });
-  const [filteredValue, setFilteredValue] = useState(allDues.dues);
+  const { data: members } = useGetMembers({ pageIndex: 0, pageSize: 1000, trackId: null });
+  const [filteredValue, setFilteredValue] = useState(allDues.dues.filter((row) => members?.content.some((member) => member.memberType === 'REGULAR' && member.id === row.memberId)));
 
   const { data: tracks } = useGetTracks();
   const [trackFilter, setTrackFilter] = useState(tracks.map(() => true));
@@ -71,9 +73,9 @@ function DefaultTable() {
     const searchName = e.target.value;
     if (searchName === '') {
       if (trackFilter.every((value) => value)) {
-        setFilteredValue(allDues.dues);
+        setFilteredValue(allDues.dues.filter((row) => members?.content.some((member) => member.memberType === 'REGULAR' && member.id === row.memberId)));
       } else {
-        setFilteredValue(allDues.dues.filter((row) => trackFilter[tracks.map((track) => track.name).indexOf(row.track.name)]));
+        setFilteredValue(allDues.dues.filter((row) => members?.content.some((member) => member.memberType === 'REGULAR' && member.id === row.memberId) && trackFilter[tracks.map((track) => track.name).indexOf(row.track.name)]));
       }
     }
     setName(searchName);
@@ -81,7 +83,9 @@ function DefaultTable() {
 
   const handleNameSearchClick = () => {
     if (filteredValue.some((row) => row.name.includes(name))) {
-      setFilteredValue(allDues.dues.filter((row) => row.name.includes(name)));
+      setFilteredValue(allDues.dues.filter((row) => row.name.includes(name) && members?.content.some((member) => member.memberType === 'REGULAR' && member.id === row.memberId)));
+    } else {
+      openSnackBar({ type: 'error', message: '해당 이름을 가진 회원이 없습니다.' });
     }
   };
 
@@ -97,9 +101,8 @@ function DefaultTable() {
     setTrackFilter((prevTrack) => {
       const updatedTrack = [...prevTrack];
       updatedTrack[trackIndex] = !updatedTrack[trackIndex];
-      setFilteredValue(allDues.dues.filter(
-        (row) => updatedTrack[tracks.map((track) => track.name).indexOf(row.track.name)],
-      ));
+      setFilteredValue(allDues.dues.filter((row) => updatedTrack[tracks.map((track) => track.name).indexOf(row.track.name)]
+      && members?.content.some((member) => member.memberType === 'REGULAR' && member.id === row.memberId)));
       return updatedTrack;
     });
   };
@@ -154,16 +157,18 @@ function DefaultTable() {
   // 연도 변경 시, 데이터를 다시 설정함
   useEffect(() => {
     setDuesYear(page ? currentYear - page + 1 : currentYear);
-    setFilteredValue(allDues.dues);
-  }, [currentYear, page, allDues.dues]);
+    if (allDues.dues) {
+      setFilteredValue(allDues.dues.filter((row) => members?.content.some((member) => member.memberType === 'REGULAR' && member.id === row.memberId)));
+    }
+  }, [currentYear, page, allDues.dues, members?.content]);
 
   // API 호출 성공 시, 데이터를 다시 불러옴
   useEffect(() => {
     if (postDuesMutation.isSuccess || putDuesMutation.isSuccess || deleteDuesMutation.isSuccess) {
       refetch();
-      setFilteredValue(allDues.dues);
+      setFilteredValue(allDues.dues.filter((row) => members?.content.some((member) => member.memberType === 'REGULAR' && member.id === row.memberId)));
     }
-  }, [postDuesMutation.isSuccess, putDuesMutation.isSuccess, deleteDuesMutation.isSuccess, refetch, allDues.dues]);
+  }, [postDuesMutation.isSuccess, putDuesMutation.isSuccess, deleteDuesMutation.isSuccess, refetch, allDues.dues, members?.content]);
 
   const goToPrevYear = () => {
     // 재학생 회비 내역이 2021년부터 시작하므로 2021년 이전으로 이동할 수 없음


### PR DESCRIPTION
## [#103] request
- 회비 페이지에서 멘토 인원을 `filter` 메서드를 통해 삭제
- 표에 없는 인원을 검색 시 검색할 수 없다고 에러 처리 추가
- 트랙 필터 default 값 추가
<!--
- Write here your development contents 
-->

## Please check if the PR fulfills these requirements

- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `main` branch?

### Screenshot
![image](https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/8bb99f17-a25c-4f35-bb0f-ddb9a74aa982)

### Precautions (main files for this PR ...)

- Close #103
