### PR TITLE
[회비 납부] 미납 횟수 순서 정렬 추가

### DIFF
--- a/src/page/DuesManagement/index.tsx
+++ b/src/page/DuesManagement/index.tsx
@@ -27,6 +27,11 @@ import { useGetMembers } from 'query/members';
 import { useSnackBar } from 'ts/useSnackBar';
 import * as S from './style';
 
+interface SortAnchorEl {
+  name: null | HTMLElement;
+  unpaidCount: null | HTMLElement;
+}
+
 function DefaultTable() {
   const navigate = useNavigate();
   const page = useQueryParam('page', 'number') as number | null;
@@ -35,7 +40,10 @@ function DefaultTable() {
   const [name, setName] = useState('');
   const [detail, setDetail] = useState<DuesDetail>({ month: 0, status: null });
   const [memoAnchorEl, setMemoAnchorEl] = useState<null | HTMLElement>(null);
-  const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
+  const [sortAnchorEl, setSortAnchorEl] = useState<SortAnchorEl>({
+    name: null,
+    unpaidCount: null,
+  });
   const memoPopOverOpen = Boolean(memoAnchorEl);
   const {
     value: isFilterModalOpen,
@@ -91,12 +99,36 @@ function DefaultTable() {
 
   const sortInAscendingOrderByName = () => {
     setFilteredValue((prevValue) => prevValue.sort((a, b) => a.name.localeCompare(b.name)));
-    setSortAnchorEl(null);
+    setSortAnchorEl((prev) => ({ ...prev, name: null }));
   };
 
   const sortInDescendingOrderByName = () => {
     setFilteredValue((prevValue) => prevValue.sort((a, b) => b.name.localeCompare(a.name)));
-    setSortAnchorEl(null);
+    setSortAnchorEl((prev) => ({ ...prev, name: null }));
+  };
+
+  const sortInAscendingOrderByUnpaidCount = () => {
+    setFilteredValue((prevValue) => prevValue.sort((a, b) => {
+      if (a.unpaidCount > b.unpaidCount) return 1;
+      if (a.unpaidCount < b.unpaidCount) return -1;
+
+      if (a.name.localeCompare(b.name) > 0) return 1;
+      if (a.name.localeCompare(b.name) < 0) return -1;
+      return 0;
+    }));
+    setSortAnchorEl((prev) => ({ ...prev, unpaidCount: null }));
+  };
+
+  const sortInDescendingOrderByUnpaidCount = () => {
+    setFilteredValue((prevValue) => prevValue.sort((a, b) => {
+      if (a.unpaidCount < b.unpaidCount) return 1;
+      if (a.unpaidCount > b.unpaidCount) return -1;
+
+      if (a.name.localeCompare(b.name) > 0) return 1;
+      if (a.name.localeCompare(b.name) < 0) return -1;
+      return 0;
+    }));
+    setSortAnchorEl((prev) => ({ ...prev, unpaidCount: null }));
   };
 
   const handleMemoClick = (e: React.MouseEvent<HTMLTableCellElement>, dueDetail: DuesDetail) => {
@@ -199,22 +231,57 @@ function DefaultTable() {
                     </Modal>
                   </div>
                 </TableCell>
-                <TableCell css={S.tableHeader}>미납 횟수</TableCell>
+                <TableCell css={S.tableHeader}>
+                  <span>미납 횟수</span>
+                  <Button
+                    type="button"
+                    onClick={(e) => setSortAnchorEl((prev) => ({ ...prev, unpaidCount: e.currentTarget }))}
+                    css={S.filterModalButton}
+                  >
+                    <Sort css={S.sortLogo} />
+                  </Button>
+                  <Popover
+                    id="simple-popover"
+                    open={Boolean(sortAnchorEl.unpaidCount)}
+                    anchorEl={sortAnchorEl.unpaidCount}
+                    onClose={() => setSortAnchorEl((prev) => ({ ...prev, unpaidCount: null }))}
+                    anchorOrigin={{
+                      vertical: 'bottom',
+                      horizontal: 'left',
+                    }}
+                  >
+                    <div css={S.sortPopover}>
+                      <h3>
+                        미납 횟수순 정렬
+                      </h3>
+                      <div css={S.sortPopoverButtonGroup}>
+                        <Button variant="contained" color="primary" onClick={sortInAscendingOrderByUnpaidCount}>
+                          <ArrowDownward />
+                          오름차순
+                        </Button>
+                        <Button variant="contained" color="primary" onClick={sortInDescendingOrderByUnpaidCount}>
+                          <ArrowUpward />
+                          내림차순
+                        </Button>
+                      </div>
+                    </div>
+                  </Popover>
+                </TableCell>
                 <TableCell css={S.tableHeader}>
                   <div css={S.nameTableCell}>
                     <span>이름</span>
                     <Button
                       type="button"
-                      onClick={(e) => setSortAnchorEl(e.currentTarget)}
+                      onClick={(e) => setSortAnchorEl((prev) => ({ ...prev, name: e.currentTarget }))}
                       css={S.filterModalButton}
                     >
                       <Sort css={S.sortLogo} />
                     </Button>
                     <Popover
                       id="simple-popover"
-                      open={Boolean(sortAnchorEl)}
-                      anchorEl={sortAnchorEl}
-                      onClose={() => setSortAnchorEl(null)}
+                      open={Boolean(sortAnchorEl.name)}
+                      anchorEl={sortAnchorEl.name}
+                      onClose={() => setSortAnchorEl((prev) => ({ ...prev, name: null }))}
                       anchorOrigin={{
                         vertical: 'bottom',
                         horizontal: 'left',

--- a/src/page/DuesManagement/index.tsx
+++ b/src/page/DuesManagement/index.tsx
@@ -256,11 +256,11 @@ function DefaultTable() {
                       </h3>
                       <div css={S.sortPopoverButtonGroup}>
                         <Button variant="contained" color="primary" onClick={sortInAscendingOrderByUnpaidCount}>
-                          <ArrowDownward />
+                          <ArrowUpward />
                           오름차순
                         </Button>
                         <Button variant="contained" color="primary" onClick={sortInDescendingOrderByUnpaidCount}>
-                          <ArrowUpward />
+                          <ArrowDownward />
                           내림차순
                         </Button>
                       </div>
@@ -293,11 +293,11 @@ function DefaultTable() {
                         </h3>
                         <div css={S.sortPopoverButtonGroup}>
                           <Button variant="contained" color="primary" onClick={sortInAscendingOrderByName}>
-                            <ArrowDownward />
+                            <ArrowUpward />
                             오름차순
                           </Button>
                           <Button variant="contained" color="primary" onClick={sortInDescendingOrderByName}>
-                            <ArrowUpward />
+                            <ArrowDownward />
                             내림차순
                           </Button>
                         </div>

--- a/src/page/EditDues/index.tsx
+++ b/src/page/EditDues/index.tsx
@@ -322,11 +322,11 @@ function DefaultTable() {
                       </h3>
                       <div css={S.sortPopoverButtonGroup}>
                         <Button variant="contained" color="primary" onClick={sortInAscendingOrderByUnpaidCount}>
-                          <ArrowDownward />
+                          <ArrowUpward />
                           오름차순
                         </Button>
                         <Button variant="contained" color="primary" onClick={sortInDescendingOrderByUnpaidCount}>
-                          <ArrowUpward />
+                          <ArrowDownward />
                           내림차순
                         </Button>
                       </div>
@@ -359,11 +359,11 @@ function DefaultTable() {
                         </h3>
                         <div css={S.sortPopoverButtonGroup}>
                           <Button variant="contained" color="primary" onClick={sortInAscendingOrderByName}>
-                            <ArrowDownward />
+                            <ArrowUpward />
                             오름차순
                           </Button>
                           <Button variant="contained" color="primary" onClick={sortInDescendingOrderByName}>
-                            <ArrowUpward />
+                            <ArrowDownward />
                             내림차순
                           </Button>
                         </div>

--- a/src/page/EditDues/index.tsx
+++ b/src/page/EditDues/index.tsx
@@ -31,6 +31,11 @@ import * as S from './style';
 
 type Status = 'PAID' | 'NOT_PAID' | 'SKIP' | 'NONE';
 
+interface SortAnchorEl {
+  name: null | HTMLElement;
+  unpaidCount: null | HTMLElement;
+}
+
 function DefaultTable() {
   const navigate = useNavigate();
   const page = useQueryParam('page', 'number') as number | null;
@@ -55,7 +60,10 @@ function DefaultTable() {
     memo: '',
   });
   const [status, setStatus] = useState<Status>('PAID');
-  const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
+  const [sortAnchorEl, setSortAnchorEl] = useState<SortAnchorEl>({
+    name: null,
+    unpaidCount: null,
+  });
 
   const openSnackBar = useSnackBar();
 
@@ -188,15 +196,40 @@ function DefaultTable() {
     setFilteredValue((prev) => {
       return prev.sort((a, b) => a.name.localeCompare(b.name));
     });
-    setSortAnchorEl(null);
+    setSortAnchorEl((prev) => ({ ...prev, name: null }));
   };
 
   const sortInDescendingOrderByName = () => {
     setFilteredValue((prev) => {
       return prev.sort((a, b) => b.name.localeCompare(a.name));
     });
-    setSortAnchorEl(null);
+    setSortAnchorEl((prev) => ({ ...prev, name: null }));
   };
+
+  const sortInAscendingOrderByUnpaidCount = () => {
+    setFilteredValue((prevValue) => prevValue.sort((a, b) => {
+      if (a.unpaidCount > b.unpaidCount) return 1;
+      if (a.unpaidCount < b.unpaidCount) return -1;
+
+      if (a.name.localeCompare(b.name) > 0) return 1;
+      if (a.name.localeCompare(b.name) < 0) return -1;
+      return 0;
+    }));
+    setSortAnchorEl((prev) => ({ ...prev, unpaidCount: null }));
+  };
+
+  const sortInDescendingOrderByUnpaidCount = () => {
+    setFilteredValue((prevValue) => prevValue.sort((a, b) => {
+      if (a.unpaidCount < b.unpaidCount) return 1;
+      if (a.unpaidCount > b.unpaidCount) return -1;
+
+      if (a.name.localeCompare(b.name) > 0) return 1;
+      if (a.name.localeCompare(b.name) < 0) return -1;
+      return 0;
+    }));
+    setSortAnchorEl((prev) => ({ ...prev, unpaidCount: null }));
+  };
+
   return (
     <>
       <div css={S.searchAndPagination}>
@@ -264,22 +297,57 @@ function DefaultTable() {
                     </Modal>
                   </div>
                 </TableCell>
-                <TableCell css={S.tableHeader}>미납 횟수</TableCell>
+                <TableCell css={S.tableHeader}>
+                  <span>미납 횟수</span>
+                  <Button
+                    type="button"
+                    onClick={(e) => setSortAnchorEl((prev) => ({ ...prev, unpaidCount: e.currentTarget }))}
+                    css={S.filterModalButton}
+                  >
+                    <Sort css={S.sortLogo} />
+                  </Button>
+                  <Popover
+                    id="simple-popover"
+                    open={Boolean(sortAnchorEl.unpaidCount)}
+                    anchorEl={sortAnchorEl.unpaidCount}
+                    onClose={() => setSortAnchorEl((prev) => ({ ...prev, unpaidCount: null }))}
+                    anchorOrigin={{
+                      vertical: 'bottom',
+                      horizontal: 'left',
+                    }}
+                  >
+                    <div css={S.sortPopover}>
+                      <h3>
+                        미납 횟수순 정렬
+                      </h3>
+                      <div css={S.sortPopoverButtonGroup}>
+                        <Button variant="contained" color="primary" onClick={sortInAscendingOrderByUnpaidCount}>
+                          <ArrowDownward />
+                          오름차순
+                        </Button>
+                        <Button variant="contained" color="primary" onClick={sortInDescendingOrderByUnpaidCount}>
+                          <ArrowUpward />
+                          내림차순
+                        </Button>
+                      </div>
+                    </div>
+                  </Popover>
+                </TableCell>
                 <TableCell css={S.tableHeader}>
                   <div css={S.nameTableCell}>
                     <span>이름</span>
                     <Button
                       type="button"
-                      onClick={(e) => setSortAnchorEl(e.currentTarget)}
+                      onClick={(e) => setSortAnchorEl((prev) => ({ ...prev, name: e.currentTarget }))}
                       css={S.filterModalButton}
                     >
                       <Sort css={S.sortLogo} />
                     </Button>
                     <Popover
                       id="simple-popover"
-                      open={Boolean(sortAnchorEl)}
-                      anchorEl={sortAnchorEl}
-                      onClose={() => setSortAnchorEl(null)}
+                      open={Boolean(sortAnchorEl.name)}
+                      anchorEl={sortAnchorEl.name}
+                      onClose={() => setSortAnchorEl((prev) => ({ ...prev, name: null }))}
                       anchorOrigin={{
                         vertical: 'bottom',
                         horizontal: 'left',


### PR DESCRIPTION
## [#152] request
- 미납 횟수 순서 정렬 추가했습니다!
- 기존에 `오름차순` `내림차순`을 나타내는 화살표가 반대로 되어 있어 수정했습니다.
<!--
- Write here your development contents 
-->

## Please check if the PR fulfills these requirements

- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `main` branch?

### Screenshot
https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/8b095534-66d1-4cbe-a3b1-1d95c394b5ba


### Precautions (main files for this PR ...)

- Close #152
