### PR TITLE
미구현 페이지 라우팅 제거

### DIFF
--- a/src/layout/SideBar/index.tsx
+++ b/src/layout/SideBar/index.tsx
@@ -52,7 +52,6 @@ export default function SideBar() {
           회원 승인
         </Button>
         <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('track')} css={S.button(currentPage === PATHS.track)}>트랙 정보</Button>
-        <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('team')} css={S.button(currentPage === PATHS.team)}>팀 정보</Button>
         <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('role')} css={S.button(currentPage === PATHS.role)}>직책 정보</Button>
         <Button color="secondary" sx={{ marginTop: '20px' }} size="large" onClick={() => navigate('reservation')} css={S.button(currentPage === PATHS.reservation)}>예약 정보</Button>
 


### PR DESCRIPTION
## [#163 ] request

<!--
- Write here your development contents 
-->
내일 스프린트 종료 이후 배포이전 미구현 된 페이지를 사용자에게 보여주지 않기위해 라우팅을 제거했습니다.
주소에 `/team`을 검색하면 접속가능하지만 사이드바에서만 제거했습니다.

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot
<img width="199" alt="image" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/51395707/15d240a5-2f88-419d-83c5-79dc06fa24c1">


### Precautions (main files for this PR ...)

- Close #163