### PR TITLE
[슬랙봇] 슬랙 동기화 버튼 추가

### DIFF
--- a/src/api/admin/index.ts
+++ b/src/api/admin/index.ts
@@ -2,3 +2,5 @@ import { accessClient } from 'api';
 
 // response가 없음
 export const acceptMember = (memberId: number) => accessClient.patch(`/admin/members/${memberId}/accept`);
+
+export const slackSync = () => accessClient.post('/admin/members/slack-sync');

--- a/src/layout/TopBar/index.tsx
+++ b/src/layout/TopBar/index.tsx
@@ -5,6 +5,8 @@ import MenuIcon from '@mui/icons-material/Menu';
 import useQueryParam from 'util/hooks/useQueryParam';
 import { PATHS } from 'util/constants/path';
 import { useEffect } from 'react';
+import { useGetMe } from 'query/members';
+import { useSlackSync } from 'query/admin';
 import * as S from './style';
 
 export const pagePath = [
@@ -63,9 +65,18 @@ export default function TopBar({ openSideBar, onClose }: Props) {
   const pages = useQueryParam('page', 'number') as number | null;
   const duesYear = pages ? currentYear - pages + 1 : currentYear;
   const { deleteMe } = useLoginState();
+  const { data: getMe } = useGetMe();
+  const { mutate: slackSync } = useSlackSync();
+
+  const memberAuthority = getMe.authority;
+
   const logOut = () => {
     deleteMe();
     navigate(PATHS.home);
+  };
+
+  const handleSlackSyncClick = () => {
+    slackSync();
   };
 
   const { title, path } = pagePath.filter((page) => page.path === location.pathname)[0];
@@ -82,7 +93,12 @@ export default function TopBar({ openSideBar, onClose }: Props) {
         </Button>
         <h1>{path.includes('dues') ? `${duesYear}년 ${title}` : title}</h1>
       </div>
-      <Button variant="contained" color="primary" sx={{ width: '100px' }} onClick={logOut}>로그아웃</Button>
+      <div css={S.buttonContainer}>
+        {(memberAuthority === 'ADMIN' || memberAuthority === 'MANAGER') && (
+        <Button variant="contained" color="primary" css={S.syncButton} onClick={handleSlackSyncClick}>슬랙 동기화</Button>
+        )}
+        <Button variant="contained" color="primary" sx={{ width: '100px' }} onClick={logOut}>로그아웃</Button>
+      </div>
     </div>
   );
 }

--- a/src/layout/TopBar/style.ts
+++ b/src/layout/TopBar/style.ts
@@ -17,3 +17,13 @@ export const flex = css`
   align-items: center;
   height: 100%;
 `;
+
+export const buttonContainer = css`
+  display: flex;
+  justify-content: flex-end;
+  gap: 20px;
+`;
+
+export const syncButton = css`
+  
+`;

--- a/src/model/admin.ts
+++ b/src/model/admin.ts
@@ -1,1 +1,6 @@
 export type AcceptMemberRequest = { memberId: number };
+
+export interface SlackSyncResponse {
+  imageSyncMemberCount: number;
+  slackSyncMemberCount: number;
+}

--- a/src/query/admin.ts
+++ b/src/query/admin.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { acceptMember } from 'api/admin';
+import { acceptMember, slackSync } from 'api/admin';
 import axios from 'axios';
+import { SlackSyncResponse } from 'model/admin';
 import { useSnackBar } from 'ts/useSnackBar';
 
 export const useAcceptMember = () => {
   const openSnackBar = useSnackBar();
   const queryClinet = useQueryClient();
   const { mutate } = useMutation({
-    mutationFn: (memberId : number) => acceptMember(memberId),
+    mutationFn: (memberId: number) => acceptMember(memberId),
     onSuccess: () => {
       queryClinet.invalidateQueries({ queryKey: ['notAuthed'] });
       openSnackBar({ type: 'success', message: '승인했습니다.' });
@@ -19,5 +20,21 @@ export const useAcceptMember = () => {
     },
   });
 
+  return { mutate };
+};
+
+export const useSlackSync = () => {
+  const openSnackBar = useSnackBar();
+  const { mutate } = useMutation<SlackSyncResponse>({
+    mutationFn: () => slackSync(),
+    onSuccess: () => {
+      openSnackBar({ type: 'success', message: '슬랙 동기화 성공' });
+    },
+    onError: (e) => {
+      if (axios.isAxiosError(e) && e.response && 'message' in e.response.data) {
+        openSnackBar({ type: 'error', message: e.response.data.message });
+      }
+    },
+  });
   return { mutate };
 };


### PR DESCRIPTION
## [Copy here issue number] request
- 공통 헤더에 슬랙 동기화 버튼을 추가했습니다.
- 아이디의 권한이 `ADMIN`, `MANGER`일 때만 보입니다.
<!--
- Write here your development contents 
-->

## Please check if the PR fulfills these requirements

- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `main` branch?

### Screenshot
<img width="1708" alt="image" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/70428b16-c2d0-41cb-a24d-852413894da9">

### Precautions (main files for this PR ...)

- Close #ISSUE_NUMBER
