### PR TITLE
[공통] useMediaQuery 추가 및 공통 페이지 모바일 뷰 추가

### DIFF
--- a/src/layout/SideBar/style.ts
+++ b/src/layout/SideBar/style.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { colors } from 'const/colors/style';
+import { mobile } from 'util/hooks/useMediaQuery';
 
 export const sideBar = css`
   display: flex;
@@ -8,6 +9,10 @@ export const sideBar = css`
   background-color: ${colors.gray};
   border-right: 1px solid ${colors.borderGray};
   box-sizing: border-box;
+
+  ${mobile} {
+    width: 175px;
+  }
 `;
 
 export const topBar = css`

--- a/src/layout/TopBar/style.ts
+++ b/src/layout/TopBar/style.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { colors } from 'const/colors/style';
+import { mobile } from 'util/hooks/useMediaQuery';
 
 export const top = css`
   width: 100%;
@@ -10,6 +11,13 @@ export const top = css`
   padding-right: 30px;
   border-bottom: 1px solid ${colors.borderGray};
   box-sizing: border-box;
+
+  ${mobile} {
+    h1 {
+      font-size: 18px;
+    }
+    padding-right: 10px;
+  }
 `;
 
 export const flex = css`
@@ -22,6 +30,15 @@ export const buttonContainer = css`
   display: flex;
   justify-content: flex-end;
   gap: 20px;
+
+  ${mobile} {
+    button {
+      font-size: 12px;
+      width: 65px;
+      height: 35px;
+      padding: 0;
+    }
+  }
 `;
 
 export const syncButton = css`

--- a/src/util/hooks/useMediaQuery.ts
+++ b/src/util/hooks/useMediaQuery.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from 'react';
+
+const MOBILE_MEDIA_QUERY = '(max-width: 576px)';
+
+export const mobile = `@media ${MOBILE_MEDIA_QUERY}`;
+
+const useMediaQuery = () => {
+  const [matches, setMatches] = useState(() => window.matchMedia(MOBILE_MEDIA_QUERY).matches);
+  const matchMediaRef = useRef<MediaQueryList | null>(null);
+
+  useEffect(() => {
+    const matchMedia = window.matchMedia(MOBILE_MEDIA_QUERY);
+    matchMediaRef.current = matchMedia;
+    function handleChange() {
+      setMatches(window.matchMedia(MOBILE_MEDIA_QUERY).matches);
+    }
+    matchMediaRef.current.addEventListener('change', handleChange);
+
+    return () => {
+      matchMediaRef.current?.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return { isMobile: matches };
+};
+
+export default useMediaQuery;


### PR DESCRIPTION
## [Copy here issue number] request
- 공통으로 사용하는 sidebar, topbar의 모바일 뷰 css 추가 (글씨 크기 및 버튼 크기, 사이드바 전체 크기를 알맞게 수정)
- useMediaQuery 추가
<!--
- Write here your development contents 
-->

## Please check if the PR fulfills these requirements

- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `main` branch?

### Screenshot
**Topbar에서 가장 긴 타이틀을 예시로 가져왔습니다.**
<img width="411" alt="image" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/3e71d1b5-2213-49fe-b7e7-17ce1188927e">
<img width="407" alt="image" src="https://github.com/BCSDLab/BCSD_INTERNAL_WEB/assets/74540646/de995b02-ff59-4158-9c1d-bb3d97ed27e7">

### Precautions (main files for this PR ...)
- emotion에서 사용하는 방식이 기존 scss와 달라 사용하는 방법 공유드립니다.
useMediaQuery에 `mobile`을 통해 모바일 css를 따로 추가할 수 있습니다.
``` ts
import { mobile } from 'util/hooks/useMediaQuery';

export const buttonContainer = css`
  display: flex;
  justify-content: flex-end;
  gap: 20px;

  ${mobile} {
    button {
      font-size: 12px;
      width: 65px;
      height: 35px;
      padding: 0;
    }
  }
`;
```
- Close #ISSUE_NUMBER
