### PR TITLE
[에러핸들링] getMe API호출시 에러 핸들링 추가

### DIFF
--- a/src/query/members.ts
+++ b/src/query/members.ts
@@ -159,6 +159,8 @@ export const useNotAuthedMember = () => {
 };
 
 export const useGetMe = () => {
+  const navigate = useNavigate();
+  const { deleteMe } = useLoginState();
   const { data, error } = useSuspenseQuery({
     queryKey: ['me'],
     queryFn: () => getMe(),
@@ -167,10 +169,11 @@ export const useGetMe = () => {
   useEffect(() => {
     if (error && axios.isAxiosError(error)) {
       if (error.response && error.response.status === 401) {
-        localStorage.clear();
+        deleteMe();
+        navigate(PATHS.home);
       }
     }
-  }, [error]);
+  }, [deleteMe, error, navigate]);
   return { data };
 };
 

--- a/src/query/members.ts
+++ b/src/query/members.ts
@@ -8,11 +8,12 @@ import {
 import {
   AdminMemberUpdate, MemberCreate, MemberDelete, MemberUpdate,
 } from 'model/member';
-import { AxiosError } from 'axios';
+import axios, { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { useSnackBar } from 'ts/useSnackBar';
 import { useLoginState } from 'store/loginStore';
 import { PATHS } from 'util/constants/path';
+import { useEffect } from 'react';
 
 interface GetMembers {
   pageIndex: number;
@@ -158,11 +159,18 @@ export const useNotAuthedMember = () => {
 };
 
 export const useGetMe = () => {
-  const { data } = useSuspenseQuery({
+  const { data, error } = useSuspenseQuery({
     queryKey: ['me'],
     queryFn: () => getMe(),
   });
 
+  useEffect(() => {
+    if (error && axios.isAxiosError(error)) {
+      if (error.response && error.response.status === 401) {
+        localStorage.clear();
+      }
+    }
+  }, [error]);
   return { data };
 };
 


### PR DESCRIPTION
## [#186] request

<!--
- Write here your development contents 
-->
- getMe API 호출시 401에러가 발생하면 로컬스토리지를 삭제하는 로직을 추가했습니다.

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Did you merge recent `main` branch?

### Screenshot

### Precautions (main files for this PR ...)

- Close #186